### PR TITLE
add non-HTTP test helpers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ java {
 }
 
 object Versions {
+    const val gson = "2.7"
     const val guava = "30.1-jre"
     const val jetty = "9.4.39.v20210325"
     const val okhttpTls = "4.8.1"
@@ -52,6 +53,7 @@ object Versions {
 
 dependencies {
     implementation("org.eclipse.jetty:jetty-server:${Versions.jetty}")
+    implementation("com.google.code.gson:gson:${Versions.gson}")
     implementation("com.google.guava:guava:${Versions.guava}")
     implementation("com.squareup.okhttp3:okhttp-tls:${Versions.okhttpTls}")
     

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,11 +56,11 @@ dependencies {
     implementation("com.google.code.gson:gson:${Versions.gson}")
     implementation("com.google.guava:guava:${Versions.guava}")
     implementation("com.squareup.okhttp3:okhttp-tls:${Versions.okhttpTls}")
-    
+    implementation("org.hamcrest:hamcrest-all:1.3")
+
     testImplementation("ch.qos.logback:logback-classic:1.1.9")
     testImplementation("com.squareup.okhttp3:okhttp:4.5.0")
     testImplementation("junit:junit:4.12")
-    testImplementation("org.hamcrest:hamcrest-all:1.3")
 }
 
 checkstyle {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.0
+version=1.1.0-SNAPSHOT
 ossrhUsername=
 ossrhPassword=
 

--- a/src/main/java/com/launchdarkly/testhelpers/Assertions.java
+++ b/src/main/java/com/launchdarkly/testhelpers/Assertions.java
@@ -10,6 +10,8 @@ import static com.launchdarkly.testhelpers.InternalHelpers.timeUnit;
  * 
  * For more specific categories of assertions, see {@link ConcurrentHelpers},
  * {@link JsonAssertions}, and {@link TypeBehavior}.
+ * 
+ * @since 1.1.0
  */
 public abstract class Assertions {
   /**

--- a/src/main/java/com/launchdarkly/testhelpers/Assertions.java
+++ b/src/main/java/com/launchdarkly/testhelpers/Assertions.java
@@ -1,0 +1,49 @@
+package com.launchdarkly.testhelpers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static com.launchdarkly.testhelpers.InternalHelpers.timeUnit;
+
+/**
+ * General test assertions that may be helpful in unit tests.
+ * 
+ * For more specific categories of assertions, see {@link ConcurrentHelpers},
+ * {@link JsonAssertions}, and {@link TypeBehavior}.
+ */
+public abstract class Assertions {
+  /**
+   * Repeatedly calls a function until it returns a non-null value or until a timeout elapses,
+   * whichever comes first.
+   * 
+   * @param <T> the return type
+   * @param timeout maximum time to wait
+   * @param timeoutUnit time unit for timeout (null defaults to milliseconds)
+   * @param interval how often to call the function
+   * @param intervalUnit time unit for interval (null defaults to milliseconds)
+   * @param fn the function to call
+   * @return the function's return value
+   * @throws AssertionError if the function did not return a non-null value before the timeout
+   */
+  public static <T> T assertPolledFunctionReturnsValue(
+      long timeout,
+      TimeUnit timeoutUnit,
+      long interval,
+      TimeUnit intervalUnit,
+      Supplier<T> fn
+      ) {
+    long deadline = System.currentTimeMillis() + timeUnit(timeoutUnit).toMillis(timeout);
+    while (System.currentTimeMillis() < deadline) {
+      T result = fn.get();
+      if (result != null) {
+        return result;
+      }
+      try {
+        Thread.sleep(timeUnit(intervalUnit).toMillis(interval));
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    throw new AssertionError("timed out after " + timeout);
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/ConcurrentHelpers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/ConcurrentHelpers.java
@@ -1,0 +1,111 @@
+package com.launchdarkly.testhelpers;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.launchdarkly.testhelpers.InternalHelpers.timeUnit;
+
+/**
+ * Helper methods and test assertions related to concurrent data structures.
+ */
+public abstract class ConcurrentHelpers {
+  /**
+   * Asserts that a future is completed within the specified timeout.
+   * 
+   * @param future the future
+   * @param timeout the maximum time to wait
+   * @param timeoutUnit the time unit for the timeout (null defaults to milliseconds)
+   * @throws AssertionError if the timeout expires
+   */
+  public static void assertFutureIsCompleted(Future<?> future, long timeout, TimeUnit timeoutUnit) {
+    try {
+      future.get(timeout, timeUnit(timeoutUnit));
+    } catch (TimeoutException e) {
+      throw new AssertionError("timed out waiting for Future");
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  /**
+   * Asserts that a future is completed within the specified timeout.
+   * 
+   * @param future the future
+   * @param timeout the maximum time to wait
+   * @param timeoutUnit the time unit for the timeout (null defaults to milliseconds)
+   * @throws AssertionError if the future is completed
+   */
+  public static void assertFutureIsNotCompleted(Future<?> future, long timeout, TimeUnit timeoutUnit) {
+    try {
+      future.get(timeout, timeUnit(timeoutUnit));
+      throw new AssertionError("Future was unexpectedly completed");
+    } catch (TimeoutException e) {
+      return;
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  /**
+   * Waits for a value to be available from a {@code BlockingQueue} and consumes the value.
+   * 
+   * @param <T> the value type
+   * @param values the queue
+   * @param timeout the maximum time to wait
+   * @param timeoutUnit the time unit for the timeout (null defaults to milliseconds)
+   * @return the value obtained from the queue
+   * @throws AssertionError if the timeout expires
+   */
+  public static <T> T awaitValue(BlockingQueue<T> values, long timeout, TimeUnit timeoutUnit) {
+    try {
+      T value = values.poll(timeout, timeUnit(timeoutUnit));
+      if (value == null) {
+        throw new AssertionError("did not receive expected value within " + timeout);
+      }
+      return value;
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Asserts that no values are available fro a queue within the specified timeout.
+   * 
+   * @param <T> the value type
+   * @param values the queue
+   * @param timeout the maximum time to wait
+   * @param timeoutUnit the time unit for the timeout (null defaults to milliseconds)
+   * @throws AssertionError if a value was available from the queue
+   */
+  public static <T> void assertNoMoreValues(BlockingQueue<T> values, long timeout, TimeUnit timeoutUnit) {
+    try {
+      T value = values.poll(timeout, timeUnit(timeoutUnit));
+      if (value != null) {
+        throw new AssertionError("expected no more values, but received: " + value);
+      }
+    } catch (InterruptedException e) {}
+  }
+  
+  /**
+   * Shortcut for calling {@code Thread.sleep()} when an {@code InterruptedException} is not
+   * expected, so you do not have to catch it.
+   * 
+   * @param delay the length of time to wait
+   * @param delayUnit the time unit for the delay (null defaults to milliseconds)
+   * @throws RuntimeException if an {@code InterruptedException} unexpectedly happened
+   */
+  public static void trySleep(long delay, TimeUnit delayUnit) {
+    try {
+      Thread.sleep(timeUnit(delayUnit).toMillis(delay));
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/ConcurrentHelpers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/ConcurrentHelpers.java
@@ -15,6 +15,8 @@ import static com.launchdarkly.testhelpers.InternalHelpers.timeUnit;
 
 /**
  * Helper methods and test assertions related to concurrent data structures.
+ * 
+ * @since 1.1.0
  */
 public abstract class ConcurrentHelpers {
   /**

--- a/src/main/java/com/launchdarkly/testhelpers/InternalHelpers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/InternalHelpers.java
@@ -3,7 +3,12 @@ package com.launchdarkly.testhelpers;
 import java.util.concurrent.TimeUnit;
 
 abstract class InternalHelpers {
-  public static TimeUnit timeUnit(TimeUnit unit) {
+  static TimeUnit timeUnit(TimeUnit unit) {
     return unit == null ? TimeUnit.MILLISECONDS : unit;
+  }
+  
+  static String timeDesc(long value, TimeUnit unit) {
+    String unitName = unit.name().toLowerCase();
+    return String.format("%d %s", value, value == 1 ? unitName.substring(0, unitName.length() - 1) : unitName);
   }
 }

--- a/src/main/java/com/launchdarkly/testhelpers/InternalHelpers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/InternalHelpers.java
@@ -1,0 +1,9 @@
+package com.launchdarkly.testhelpers;
+
+import java.util.concurrent.TimeUnit;
+
+abstract class InternalHelpers {
+  public static TimeUnit timeUnit(TimeUnit unit) {
+    return unit == null ? TimeUnit.MILLISECONDS : unit;
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/InternalHelpers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/InternalHelpers.java
@@ -8,7 +8,7 @@ abstract class InternalHelpers {
   }
   
   static String timeDesc(long value, TimeUnit unit) {
-    String unitName = unit.name().toLowerCase();
+    String unitName = timeUnit(unit).name().toLowerCase();
     return String.format("%d %s", value, value == 1 ? unitName.substring(0, unitName.length() - 1) : unitName);
   }
 }

--- a/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java
+++ b/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java
@@ -1,0 +1,200 @@
+package com.launchdarkly.testhelpers;
+
+import com.google.common.base.Joiner;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test assertions related to JSON.
+ * 
+ * @since 1.1.0
+ */
+public abstract class JsonAssertions {
+  private static final Gson gson = new Gson();
+  
+  /**
+   * Parses two strings as JSON and compares them for deep equality. If they are unequal,
+   * it tries to describe the difference as specifically as possible by recursing into
+   * object properties or array elements.
+   * 
+   * @param expected the expected JSON string
+   * @param actual the actual JSON string
+   * @throws AssertionError if the values are not deeply equal, or are not valid JSON
+   */
+  public static void assertJsonEquals(String expected, String actual) {
+    JsonElement expectedJson, actualJson;
+    try {
+      expectedJson = gson.fromJson(expected, JsonElement.class);
+    } catch (Exception e) {
+      throw new AssertionError("expected string is not valid JSON: " + e);
+    }
+    try {
+      actualJson = gson.fromJson(actual, JsonElement.class);
+    } catch (Exception e) {
+      throw new AssertionError("actual string is not valid JSON: " + e);
+    }
+    if (actualJson.equals(expectedJson)) {
+      return;
+    }
+    String diff = describeJsonDifference(expectedJson, actualJson, "", false);
+    if (diff == null) {
+      diff = "expected: " + expected + "\nactual: " + actual;
+    } else {
+      diff = diff + "\nfull actual JSON string: " + actual;
+    }
+    throw new AssertionError("JSON strings did not match\n" + diff);
+  }
+  
+  /**
+   * Same as {@link #assertJsonEquals(String, String)} except that it allows any JSON
+   * objects in the actual data to contain extra properties that are not in the expected
+   * data.
+   * 
+   * @param expectedSubset the expected JSON string
+   * @param actual the actual JSON string
+   * @throws AssertionError if the expected values are not a subset of the actual
+   *   values, or if the strings are not valid JSON
+   */
+  public static void assertJsonSubset(String expectedSubset, String actual) {
+    JsonElement expectedJson, actualJson;
+    try {
+      expectedJson = gson.fromJson(expectedSubset, JsonElement.class);
+    } catch (Exception e) {
+      throw new AssertionError("expected string is not valid JSON: " + e);
+    }
+    try {
+      actualJson = gson.fromJson(actual, JsonElement.class);
+    } catch (Exception e) {
+      throw new AssertionError("actual string is not valid JSON: " + e);
+    }
+    if (isJsonSubset(expectedJson, actualJson)) {
+      return;
+    }
+    String diff = describeJsonDifference(expectedJson, actualJson, "", true);
+    if (diff == null) {
+      diff = "expected: " + expectedSubset + "\nactual: " + actual;
+    } else {
+      diff = diff + "\nfull actual JSON string: " + actual;
+    }
+    throw new AssertionError("JSON string did not contain expected properties\n" + diff);
+  }
+  
+  private static boolean isJsonSubset(JsonElement expected, JsonElement actual) {
+    if (expected instanceof JsonObject && actual instanceof JsonObject) {
+      JsonObject eo = (JsonObject)expected, ao = (JsonObject)actual;
+      for (Map.Entry<String, JsonElement> e: eo.entrySet()) {
+        if (!ao.has(e.getKey()) || !isJsonSubset(e.getValue(), ao.get(e.getKey()))) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (expected instanceof JsonArray && actual instanceof JsonArray) {
+      JsonArray ea = (JsonArray)expected, aa = (JsonArray)actual;
+      if (ea.size() != aa.size()) {
+        return false;
+      }
+      for (int i = 0; i < ea.size(); i++) {
+        if (!isJsonSubset(ea.get(i), aa.get(i))) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return actual.equals(expected);
+  }
+  
+  private static String describeJsonDifference(
+      JsonElement expected,
+      JsonElement actual,
+      String prefix,
+      boolean allowExtraProps
+      ) {
+    if (actual instanceof JsonObject && expected instanceof JsonObject) {
+      return describeJsonObjectDifference((JsonObject)expected, (JsonObject)actual, prefix, allowExtraProps);
+    }
+    if (actual instanceof JsonArray && expected instanceof JsonArray) {
+      return describeJsonArrayDifference((JsonArray)expected, (JsonArray)actual, prefix, allowExtraProps);
+    }
+    return null;
+  }
+
+  private static String describeJsonObjectDifference(
+      JsonObject expected,
+      JsonObject actual,
+      String prefix,
+      boolean allowExtraProps
+      ) {
+    List<String> diffs = new ArrayList<>();
+    Set<String> allKeys = new HashSet<>();
+    for (Map.Entry<String, JsonElement> e: expected.entrySet()) {
+      allKeys.add(e.getKey());
+    }
+    for (Map.Entry<String, JsonElement> e: actual.entrySet()) {
+      allKeys.add(e.getKey());
+    }
+    for (String key: allKeys) {
+      String prefixedKey = prefix + (prefix == "" ? "" : ".") + key;
+      String expectedDesc = null, actualDesc = null, detailDiff = null;
+      if (expected.has(key)) {
+        if (actual.has(key)) {
+          JsonElement actualValue = actual.get(key), expectedValue = expected.get(key);
+          if (!actualValue.equals(expectedValue)) {
+            expectedDesc = expectedValue.toString();
+            actualDesc = actualValue.toString();
+            detailDiff = describeJsonDifference(expectedValue, actualValue, prefixedKey, allowExtraProps);
+          }
+        } else {
+          expectedDesc = expected.get(key).toString();
+          actualDesc = "<absent>";
+        }
+      } else if (!allowExtraProps) {
+        actualDesc = actual.get(key).toString();
+        expectedDesc = "<absent>";
+      }
+      if (expectedDesc != null || actualDesc != null) {
+        if (detailDiff != null) {
+          diffs.add(detailDiff);
+        } else {
+          diffs.add(String.format("at \"%s\": expected = %s, actual = %s", prefixedKey,
+              expectedDesc, actualDesc));
+        }
+      }
+    }
+    return Joiner.on("\n").join(diffs);
+  }
+
+  private static String describeJsonArrayDifference(
+      JsonArray expected,
+      JsonArray actual,
+      String prefix,
+      boolean allowExtraProps
+      ) {
+    if (expected.size() != actual.size()) {
+      return null; // can't provide a detailed diff, just show the whole values
+    }
+    List<String> diffs = new ArrayList<>();
+    for (int i = 0; i < expected.size(); i++) {
+      String prefixedIndex = String.format("%s[%d]", prefix, i);
+      JsonElement actualValue = actual.get(i), expectedValue = expected.get(i);
+      if (!actualValue.equals(expectedValue)) {
+        String detailDiff = describeJsonDifference(expectedValue, actualValue, prefixedIndex, allowExtraProps);
+        if (detailDiff != null) {
+          diffs.add(detailDiff);
+        } else {
+          diffs.add(String.format("at \"%s\": expected = %s, actual = %s", prefixedIndex,
+              expectedValue.toString(), actualValue.toString()));
+        }
+      }
+    }
+    return Joiner.on("\n").join(diffs);
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java
+++ b/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java
@@ -1,13 +1,11 @@
 package com.launchdarkly.testhelpers;
 
 import com.google.common.base.Joiner;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.hamcrest.Description;
-import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
@@ -16,7 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.launchdarkly.testhelpers.JsonTestValue.jsonFromValue;
@@ -29,8 +26,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * @since 1.1.0
  */
 public abstract class JsonAssertions {
-  private static final Gson gson = new Gson();
-  
   /**
    * Parses two strings as JSON and compares them for deep equality. If they are unequal,
    * it tries to describe the difference as specifically as possible by recursing into
@@ -339,37 +334,6 @@ public abstract class JsonAssertions {
         }
         mismatchDescription.appendText("not a JSON array: ").appendText(actual.raw);
         return false;
-      }
-    };
-  }
-  
-  private static interface Function3<A, B, C, D> {
-    D apply(A a, B b, C c);
-  }
-  
-  private static Matcher<String> jsonParsingMatcher(Consumer<Description> describeFn,
-      Function3<JsonElement, String, Description, Boolean> matchFn) {
-    return new DiagnosingMatcher<String>() {
-      @Override
-      public void describeTo(Description description) {
-        describeFn.accept(description);
-      }
-      
-      @Override
-      protected boolean matches(Object item, Description mismatchDescription) {
-        if (item == null) {
-          mismatchDescription.appendText("no value");
-          return false;
-        }
-        String actual = (String)item;
-        JsonElement actualJson;
-        try {
-          actualJson = gson.fromJson(actual, JsonElement.class);
-        } catch (Exception e) {
-          mismatchDescription.appendText("not valid JSON: " + e).appendText(actual);
-          return false;
-        }
-        return matchFn.apply(actualJson, actual, mismatchDescription);
       }
     };
   }

--- a/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java
+++ b/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java
@@ -22,7 +22,38 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test assertions and matchers related to JSON.
- * 
+ * <p>
+ * The {@code assert} methods here provide simple assertions for strings that are assumed
+ * to contain JSON.
+ * <p>
+ * The other methods are factories for type-safe Hamcrest matchers. These are much more
+ * flexible, as you can use standard Hamcrest combinators like {@code allOf} or {@code not}.
+ * These use {@link JsonTestValue} as their type parameter, to prevent confusion between
+ * test code that operates on JSON strings and test code that operates on other kinds of
+ * strings. {@link JsonTestValue} is easily convertible from strings or other types;
+ * see {@link JsonTestValue#jsonOf(String)} and {@link JsonTestValue#jsonFromValue(Object)}.
+ * <p>
+ * Examples:
+ * <pre><code>
+ *     // check for the exact JSON properties {"a": 1, "b": 2} in any order
+ *     assertThat(jsonOf(myString), jsonEquals("{\"a\":1, \"b\": 2}");
+ *     
+ *     // check that a JSON object's property "p" is equal to a specific boolean value
+ *     assertThat(jsonOf(myString), jsonProperty("p", someBooleanValue));
+ *     
+ *     // check that a JSON object's property "p" is either null or omitted
+ *     assertThat(jsonOf(myString),
+ *         jsonProperty("p", anyOf(jsonNull(), jsonUndefined())));
+ *     
+ *     // check that a JSON object's property "p" is an array containing a specific value
+ *     assertThat(jsonOf(myString),
+ *         jsonProperty("p", isJsonArray(hasItem(jsonEqualsValue(someValue)))));
+ * </code></pre>
+ * <p>
+ * When comparing unequal JSON objects or arrays, these methods will do their best to
+ * show you a localized difference such as a specific property, rather than only showing
+ * the entire actual and expected values. 
+ *    
  * @since 1.1.0
  */
 public abstract class JsonAssertions {

--- a/src/main/java/com/launchdarkly/testhelpers/JsonTestValue.java
+++ b/src/main/java/com/launchdarkly/testhelpers/JsonTestValue.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonElement;
  * which are not relevant to the test logic.
  * 
  * @see JsonAssertions
+ * @since 1.1.0
  */
 public final class JsonTestValue {
   private static final Gson gson = new Gson();

--- a/src/main/java/com/launchdarkly/testhelpers/JsonTestValue.java
+++ b/src/main/java/com/launchdarkly/testhelpers/JsonTestValue.java
@@ -1,0 +1,76 @@
+package com.launchdarkly.testhelpers;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+/**
+ * A simple wrapper for a string that can be parsed as JSON for tests.
+ * <p>
+ * This class provides strong typing so that it is clear when test matchers apply to JSON
+ * values versus strings, and hides the implementation details of parsing and serialization
+ * which are not relevant to the test logic.
+ * 
+ * @see JsonAssertions
+ */
+public final class JsonTestValue {
+  private static final Gson gson = new Gson();
+  
+  final String raw;
+  final JsonElement parsed;
+  
+  private JsonTestValue(String raw, JsonElement parsed) {
+    this.raw = raw;
+    this.parsed = parsed;
+  }
+  
+  /**
+   * Creates a {@code JsonTestValue} from a string that should contain JSON.
+   * <p>
+   * This method fails immediately for any string that is not well-formed JSON. However, if
+   * it is a null reference, it returns an "undefined" instance that will return {@code false}
+   * from {@link #isDefined()}.
+   * 
+   * @param raw the input string
+   * @return a {@code JsonTestValue}
+   * @throws AssertionError for malformed JSON
+   */
+  public static JsonTestValue jsonOf(String raw) {
+    if (raw == null) {
+      return new JsonTestValue(null, null);
+    }
+    try {
+      return new JsonTestValue(raw, gson.fromJson(raw, JsonElement.class));
+    } catch (Exception e) {
+      throw new AssertionError("not valid JSON (" + e + "): " + raw);
+    }
+  }
+  
+  static JsonTestValue ofParsed(JsonElement json) {
+    return new JsonTestValue(json == null ? null : gson.toJson(json), json);
+  }
+  
+  /**
+   * Creates a {@code JsonTestValue} by serializing an arbitrary value to JSON. For
+   * instance, {@code jsonFromValue(true)} is equivalent to {@code jsonOf("true")}.
+   * 
+   * @param value an arbitrary value
+   * @return a {@code JsonTestValue}
+   */
+  public static JsonTestValue jsonFromValue(Object value) {
+    return ofParsed(gson.toJsonTree(value));
+  }
+  
+  @Override
+  public String toString() {
+    return raw == null ? "<no value>" : raw;
+  }
+  
+  /**
+   * Returns true if there is a value (that is, the original string was not a null reference).
+   * 
+   * @return true if defined
+   */
+  public boolean isDefined() {
+    return raw != null;
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/TempDir.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TempDir.java
@@ -25,6 +25,7 @@ import java.nio.file.attribute.BasicFileAttributes;
  * not need to catch or declare them.
  * 
  * @see TempDir
+ * @since 1.1.0
  */
 public final class TempDir implements AutoCloseable {
   private final Path path;

--- a/src/main/java/com/launchdarkly/testhelpers/TempDir.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TempDir.java
@@ -1,0 +1,114 @@
+package com.launchdarkly.testhelpers;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * Provides a temporary directory for use by a test. The {@link #close} method deletes
+ * the directory, so a try-with-resources block will ensure that it is cleaned up.
+ * <p>
+ * All methods that could cause an IOException will throw it as a RuntimeException
+ * instead, so tests do not need to catch IOException.
+ * 
+ * <pre><code>
+ *     try (TempDir dir = TempDir.create()) {
+ *         TempFile f = dir.tempFile(".txt");
+ *         f.setContents("test data");
+ *     }
+ * </code></pre>
+ * 
+ * All IOExceptions are rethrown as RuntimeExceptions so that the test code does
+ * not need to catch or declare them.
+ * 
+ * @see TempDir
+ */
+public final class TempDir implements AutoCloseable {
+  private final Path path;
+  
+  private TempDir(Path path) {
+    this.path = path;
+  }
+  
+  /**
+   * Creates a temporary directory.
+   * 
+   * @return a directory object
+   */
+  public static TempDir create() {
+    try {
+      return new TempDir(Files.createTempDirectory("java-sdk-tests"));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Returns the directory path.
+   * 
+   * @return a path
+   */
+  public Path getPath() {
+    return path;
+  }
+  
+  /**
+   * Calls {@link #delete()} if the directory still exists.
+   */
+  @Override
+  public void close() {
+    if (Files.exists(path)) {
+      delete();
+    }
+  }
+
+  /**
+   * Deletes the directory and all its contents.
+   */
+  public void delete() {
+    try {
+      Files.walkFileTree(path, 
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+          }
+          
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+          }
+      });
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  /**
+   * Creates a temporary file within the directory.
+   * 
+   * @return a file object
+   */
+  public TempFile tempFile() {
+    return tempFile("");
+  }
+  
+  /**
+   * Creates a temporary file within the directory.
+   * 
+   * @param suffix optional filename suffix, may be empty
+   * @return a file object
+   */
+  public TempFile tempFile(String suffix) {
+    try {
+      return new TempFile(Files.createTempFile(path, "java-sdk-tests", suffix));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/TempFile.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TempFile.java
@@ -1,0 +1,93 @@
+package com.launchdarkly.testhelpers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Provides a temporary file for use by a test. The {@link #close} method deletes
+ * the directory, so a try-with-resources block will ensure that it is cleaned up.
+ * 
+ * <pre><code>
+ *     try (TempFile f = TempFile.create(".txt") {
+ *         f.setContents("test data");
+ *     }
+ * </code></pre>
+ * 
+ * All IOExceptions are rethrown as RuntimeExceptions so that the test code does
+ * not need to catch or declare them.
+ * 
+ * @see TempDir
+ */
+public final class TempFile implements AutoCloseable {
+  private final Path path;
+  
+  TempFile(Path path) {
+    this.path = path;
+  }
+
+  /**
+   * Creates a temporary file in the default directory for temporary files.
+   * 
+   * @return a file object
+   * @see TempDir#tempFile(String)
+   */
+  public static TempFile create() {
+    return create("");
+  }
+
+  /**
+   * Creates a temporary file in the default directory for temporary files.
+   * 
+   * @param suffix optional filename suffix, may be empty
+   * @return a file object
+   * @see TempDir#tempFile(String)
+   */
+  public static TempFile create(String suffix) {
+    try {
+      return new TempFile(Files.createTempFile("", suffix));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (Files.exists(path)) {
+      delete();
+    }
+  }
+  
+  /**
+   * Returns the file path.
+   * 
+   * @return the file path
+   */
+  public Path getPath() {
+    return path;
+  }
+  
+  /**
+   * Deletes the file.
+   */
+  public void delete() {
+    try {
+      Files.delete(path);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  /**
+   * Replaces the file's contents with the specified data (in UTF-8 encoding).
+   * 
+   * @param content the new content
+   */
+  public void setContents(String content) {
+    try {
+      Files.write(path, content.getBytes("UTF-8"));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/TempFile.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TempFile.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
  * not need to catch or declare them.
  * 
  * @see TempDir
+ * @since 1.1.0
  */
 public final class TempFile implements AutoCloseable {
   private final Path path;

--- a/src/main/java/com/launchdarkly/testhelpers/TypeBehavior.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TypeBehavior.java
@@ -1,0 +1,118 @@
+package com.launchdarkly.testhelpers;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test assertions that may be helpful in testing generic type behavior.
+ *
+ * @since 1.1.0
+ */
+public abstract class TypeBehavior {
+  /**
+   * A supplier interface for use {@link #checkEqualsAndHashCode(List)}.
+   *
+   * @param <T> the value type
+   */
+  public interface ValueFactory<T> {
+    /**
+     * Returns a new instance of the value type.
+     * 
+     * @return an instance
+     */
+    T get();
+  }
+  
+  /**
+   * Creates a simple {@link ValueFactory} that returns the specified instances in order
+   * each time it is called. After all instances are used, it starts over at the first.
+   * This is for use with {@link #checkEqualsAndHashCode(List)}.
+   * 
+   * @param <T> the value type
+   * @param values the instances
+   * @return a value factory
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> ValueFactory<T> valueFactoryFromInstances(T...values) {
+    AtomicInteger counter = new AtomicInteger(0);
+    return () -> {
+      int i = counter.getAndIncrement();
+      if (counter.get() >= values.length) {
+        counter.set(0);
+      }
+      return values[i];
+    };
+  }
+  
+  /**
+   * Implements a standard test suite for custom implementations of {@code equals()} and
+   * {@code hashCode()}.
+   * <p>
+   * The {@code valueFactories} parameter is a list of value factories. Each factory must
+   * produce only instances that are equal to each other, and not equal to the instances
+   * produced by any of the other factories. The test suite verifies the following:
+   * <ul>
+   * <li> For any instance {@code a} created by any of the factories, {@code a.equals(a)}
+   * is true, {@code a.equals(null)} is false, and {@code a.equals(x)} where {@code x} is
+   * an instance of a different class is false. </li> 
+   * <li> For any two instances {@code a} and {@code b} created by the same factory,
+   * {@code a.equals(b)}, {@code b.equals(a)}, and {@code a.hashCode() == b.hashCode()}
+   * are all true. </li>
+   * <li> For any two instances {@code a} and {@code b} created by different factories,
+   * {@code a.equals(b)} and {@code b.equals(a)} are false (there is no requirement that
+   * the hash codes are different). </li>
+   * </ul>
+   * 
+   * @param <T> the value type
+   * @param valueFactories list of factories for distinct values
+   * @throws AssertionError if a test condition fails
+   */
+  public static <T> void checkEqualsAndHashCode(List<ValueFactory<T>> valueFactories) {
+    for (int i = 0; i < valueFactories.size(); i++) {
+      for (int j = 0; j < valueFactories.size(); j++) {
+        T value1 = valueFactories.get(i).get();
+        T value2 = valueFactories.get(j).get();
+        if (value1 == value2) {
+          throw new AssertionError("value factory must not return the same instance twice");
+        }
+        if (i == j) {
+          // instance is equal to itself
+          if (!value1.equals(value1)) {
+            throw new AssertionError("value was not equal to itself: " + value1);
+          }
+ 
+          // commutative equality
+          if (!value1.equals(value2)) {
+            throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was false");
+          }
+          if (!value2.equals(value1)) {
+            throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was true, but (" +
+                value2 + ").equals(" + value1 + ") was false");
+          }
+ 
+          // equal hash code
+          if (value1.hashCode() != value2.hashCode()) {
+            throw new AssertionError("(" + value1 + ").hashCode() was " + value1.hashCode() + " but ("
+                + value2 + ").hashCode() was " + value2.hashCode());
+          }
+ 
+          // unequal to null, unequal to value of wrong class
+          if (value1.equals(null)) {
+            throw new AssertionError("value was equal to null: " + value1);
+          }
+          if (value1.equals(new Object())) {
+            throw new AssertionError("value was equal to Object: " + value1);
+          }
+        } else {
+          // commutative inequality
+          if (value1.equals(value2)) {
+            throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was true");
+          }
+          if (value2.equals(value1)) {
+            throw new AssertionError("(" + value2 + ").equals(" + value1 + ") was true");
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/AssertionsTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/AssertionsTest.java
@@ -1,0 +1,51 @@
+package com.launchdarkly.testhelpers;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@SuppressWarnings("javadoc")
+public class AssertionsTest {
+  @Test
+  public void assertPolledFunctionReturnsValueSuccessOnFirstTry() {
+    String value = Assertions.assertPolledFunctionReturnsValue(
+        1, TimeUnit.SECONDS,
+        10, TimeUnit.MILLISECONDS,
+        () -> "yes"
+        );
+    assertThat(value, equalTo("yes"));
+  }
+  
+  @Test
+  public void assertPolledFunctionReturnsValueSuccessOnLaterTry() {
+    AtomicInteger i = new AtomicInteger(0);
+    String value = Assertions.assertPolledFunctionReturnsValue(
+        200, TimeUnit.MILLISECONDS,
+        10, TimeUnit.MILLISECONDS,
+        () -> {
+          return i.incrementAndGet() >= 5 ? "yes" : null;
+        });
+    assertThat(value, equalTo("yes"));
+  }
+
+  @Test
+  public void assertPolledFunctionReturnsValueFailure() {
+    AtomicInteger i = new AtomicInteger(0);
+    try {
+      Assertions.assertPolledFunctionReturnsValue(
+          200, TimeUnit.MILLISECONDS,
+          10, TimeUnit.MILLISECONDS,
+          () -> {
+            i.incrementAndGet();
+            return null;
+          });
+    } catch (AssertionError e) {
+      assertThat(i.get(), Matchers.greaterThan(1));
+    }
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/AssertionsTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/AssertionsTest.java
@@ -1,6 +1,5 @@
 package com.launchdarkly.testhelpers;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -8,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 @SuppressWarnings("javadoc")
 public class AssertionsTest {
@@ -36,7 +36,7 @@ public class AssertionsTest {
   @Test
   public void assertPolledFunctionReturnsValueFailure() {
     AtomicInteger i = new AtomicInteger(0);
-    try {
+    requireAssertionError(() -> {
       Assertions.assertPolledFunctionReturnsValue(
           200, TimeUnit.MILLISECONDS,
           10, TimeUnit.MILLISECONDS,
@@ -44,8 +44,16 @@ public class AssertionsTest {
             i.incrementAndGet();
             return null;
           });
+    });
+    assertThat(i.get(), greaterThan(1));
+  }
+  
+  public static String requireAssertionError(Runnable action) {
+    try {
+      action.run();
+      throw new AssertionError("expected AssertionError, did not get one");
     } catch (AssertionError e) {
-      assertThat(i.get(), Matchers.greaterThan(1));
+      return e.getMessage();
     }
   }
 }

--- a/src/test/java/com/launchdarkly/testhelpers/ConcurrentHelpersTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/ConcurrentHelpersTest.java
@@ -1,0 +1,48 @@
+package com.launchdarkly.testhelpers;
+
+import org.junit.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.launchdarkly.testhelpers.ConcurrentHelpers.assertNoMoreValues;
+import static com.launchdarkly.testhelpers.ConcurrentHelpers.awaitValue;
+import static com.launchdarkly.testhelpers.ConcurrentHelpers.trySleep;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@SuppressWarnings("javadoc")
+public class ConcurrentHelpersTest {
+  @Test
+  public void awaitValueSuccess() {
+    BlockingQueue<String> q = new LinkedBlockingQueue<>();
+    new Thread(() -> {
+      q.add("a");
+    }).start();
+    String value = awaitValue(q, 1, TimeUnit.SECONDS);
+    assertThat(value, equalTo("a"));
+  }
+  
+  @Test(expected=AssertionError.class)
+  public void awaitValueFailure() {
+    BlockingQueue<String> q = new LinkedBlockingQueue<>();
+    awaitValue(q, 100, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void assertNoMoreValuesSuccess() {
+    BlockingQueue<String> q = new LinkedBlockingQueue<>();
+    assertNoMoreValues(q, 50, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected=AssertionError.class)
+  public void assertNoMoreValuesFailure() {
+    BlockingQueue<String> q = new LinkedBlockingQueue<>();
+    new Thread(() -> {
+      trySleep(10, TimeUnit.MILLISECONDS);
+      q.add("a");
+    }).start();
+    assertNoMoreValues(q, 100, TimeUnit.MILLISECONDS);
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/ConcurrentHelpersTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/ConcurrentHelpersTest.java
@@ -3,13 +3,18 @@ package com.launchdarkly.testhelpers;
 import org.junit.Test;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static com.launchdarkly.testhelpers.AssertionsTest.requireAssertionError;
+import static com.launchdarkly.testhelpers.ConcurrentHelpers.assertFutureIsCompleted;
 import static com.launchdarkly.testhelpers.ConcurrentHelpers.assertNoMoreValues;
 import static com.launchdarkly.testhelpers.ConcurrentHelpers.awaitValue;
+import static com.launchdarkly.testhelpers.ConcurrentHelpers.isCompletedWithin;
 import static com.launchdarkly.testhelpers.ConcurrentHelpers.trySleep;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @SuppressWarnings("javadoc")
@@ -24,10 +29,13 @@ public class ConcurrentHelpersTest {
     assertThat(value, equalTo("a"));
   }
   
-  @Test(expected=AssertionError.class)
+  @Test
   public void awaitValueFailure() {
     BlockingQueue<String> q = new LinkedBlockingQueue<>();
-    awaitValue(q, 100, TimeUnit.MILLISECONDS);
+    String message = requireAssertionError(() -> {
+      awaitValue(q, 100, TimeUnit.MILLISECONDS);
+    });
+    assertThat(message, equalTo("did not receive a value within 100 milliseconds"));
   }
 
   @Test
@@ -36,13 +44,54 @@ public class ConcurrentHelpersTest {
     assertNoMoreValues(q, 50, TimeUnit.MILLISECONDS);
   }
 
-  @Test(expected=AssertionError.class)
+  @Test
   public void assertNoMoreValuesFailure() {
     BlockingQueue<String> q = new LinkedBlockingQueue<>();
     new Thread(() -> {
       trySleep(10, TimeUnit.MILLISECONDS);
       q.add("a");
     }).start();
-    assertNoMoreValues(q, 100, TimeUnit.MILLISECONDS);
+    String message = requireAssertionError(() -> {
+      assertNoMoreValues(q, 100, TimeUnit.MILLISECONDS);
+    });
+    assertThat(message, equalTo("expected no more values, but received: a"));
+  }
+  
+  @Test
+  public void assertFutureIsCompletedSuccess() {
+    CompletableFuture<String> f = new CompletableFuture<String>();
+    new Thread(() -> {
+      f.complete("a");
+    }).start();
+    String value = assertFutureIsCompleted(f, 1, TimeUnit.SECONDS);
+    assertThat(value, equalTo("a"));
+  }
+
+  @Test
+  public void assertFutureIsCompletedFailure() {
+    CompletableFuture<String> f = new CompletableFuture<String>();
+    String message = requireAssertionError(() -> {
+      assertFutureIsCompleted(f, 50, TimeUnit.MILLISECONDS);
+    });
+    assertThat(message, equalTo("Future was not completed within 50 milliseconds"));
+  }
+  
+  @Test
+  public void futureIsCompletedMatcherSuccess() {
+    CompletableFuture<String> f = new CompletableFuture<String>();
+    new Thread(() -> {
+      f.complete("a");
+    }).start();
+    assertThat(f, isCompletedWithin(1, TimeUnit.SECONDS));
+  }
+  
+  @Test
+  public void futureIsCompletedMatcherFailure() {
+    CompletableFuture<String> f = new CompletableFuture<String>();
+    String message = requireAssertionError(() -> {
+      assertThat(f, isCompletedWithin(50, TimeUnit.MILLISECONDS));
+    });
+    assertThat(message, containsString("Expected: Future is completed within 50 milliseconds"));
+    assertThat(message, containsString("but: timed out"));
   }
 }

--- a/src/test/java/com/launchdarkly/testhelpers/JsonAssertionsTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/JsonAssertionsTest.java
@@ -1,0 +1,112 @@
+package com.launchdarkly.testhelpers;
+
+import org.junit.Test;
+
+import static com.launchdarkly.testhelpers.JsonAssertions.assertJsonEquals;
+import static com.launchdarkly.testhelpers.JsonAssertions.assertJsonSubset;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings("javadoc")
+public class JsonAssertionsTest {
+  @Test
+  public void assertJsonEqualsSuccess() {
+    assertJsonEquals("null", "null");
+    assertJsonEquals("true", "true");
+    assertJsonEquals("1", "1");
+    assertJsonEquals("\"x\"", "\"x\"");
+    assertJsonEquals("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2},\"a\":1}");
+    assertJsonEquals("[1,2,[3,4]]","[1,2,[3,4]]");
+  }
+  
+  @Test
+  public void assertJsonEqualsFailureWithNoDetailedDiff() {
+    assertThat(jsonEqualsFailureMessage("null", "true"),
+        equalTo("expected: null\nactual: true"));
+    assertThat(jsonEqualsFailureMessage("false", "true"),
+        equalTo("expected: false\nactual: true"));
+    assertThat(jsonEqualsFailureMessage("{\"a\":1}", "3"),
+        equalTo("expected: {\"a\":1}\nactual: 3"));
+    assertThat(jsonEqualsFailureMessage("[1,2]", "3"),
+        equalTo("expected: [1,2]\nactual: 3"));
+    assertThat(jsonEqualsFailureMessage("[1,2]", "[1,2,3]"),
+        equalTo("expected: [1,2]\nactual: [1,2,3]"));
+  }
+
+  @Test
+  public void assertJsonEqualsFailureWithDetailedDiff() {
+    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":2}", "{\"a\":1,\"b\":3}"),
+        equalTo("at \"b\": expected = 2, actual = 3"));
+
+    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":2}", "{\"a\":1}"),
+        equalTo("at \"b\": expected = 2, actual = <absent>"));
+
+    assertThat(jsonEqualsFailureMessage("{\"a\":1}", "{\"a\":1,\"b\":2}"),
+        equalTo("at \"b\": expected = <absent>, actual = 2"));
+
+    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":{\"c\":2}}", "{\"a\":1,\"b\":{\"c\":3}}"),
+        equalTo("at \"b.c\": expected = 2, actual = 3"));
+
+    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":[2,3]}", "{\"a\":1,\"b\":[3,3]}"),
+        equalTo("at \"b[0]\": expected = 2, actual = 3"));
+
+    assertThat(jsonEqualsFailureMessage("[100,200,300]", "[100,201,300]"),
+        equalTo("at \"[1]\": expected = 200, actual = 201"));
+
+    assertThat(jsonEqualsFailureMessage("[100,[200,210],300]", "[100,[201,210],300]"),
+        equalTo("at \"[1][0]\": expected = 200, actual = 201"));
+
+    assertThat(jsonEqualsFailureMessage("[100,{\"a\":1},300]", "[100,{\"a\":2},300]"),
+        equalTo("at \"[1].a\": expected = 1, actual = 2"));
+  }
+  
+  @Test
+  public void assertJsonSubsetSuccess() {
+   assertJsonSubset("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1}");
+   assertJsonSubset("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1,\"c\":3}");
+   assertJsonSubset("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2,\"d\":3},\"a\":1}");
+  }
+  
+  @Test
+  public void assertJsonSubsetFailure() {
+    assertThat(jsonSubsetFailureMessage("{\"a\":1}", "{\"a\":0,\"b\":2,\"c\":3}"),
+        equalTo("at \"a\": expected = 1, actual = 0"));
+
+    assertThat(jsonSubsetFailureMessage("{\"a\":1}", "{\"b\":2,\"c\":3}"),
+        equalTo("at \"a\": expected = 1, actual = <absent>"));
+
+    assertThat(jsonSubsetFailureMessage("{\"b\":2,\"a\":1,\"c\":3}", "{\"a\":1,\"b\":2}"),
+        equalTo("at \"c\": expected = 3, actual = <absent>"));
+
+    assertThat(jsonSubsetFailureMessage("{\"b\":{\"c\":2,\"d\":3},\"a\":1}", "{\"a\":1,\"b\":{\"c\":2}}"),
+        equalTo("at \"b.d\": expected = 3, actual = <absent>"));
+  }
+  
+  private static String jsonEqualsFailureMessage(String expected, String actual) {
+    try {
+      assertJsonEquals(expected, actual);
+      fail("expected AssertionFailedException");
+      return null;
+    } catch (AssertionError e) {
+      String m = e.getMessage();
+      String expectedPrefix = "JSON strings did not match\n";
+      assertThat(m, startsWith(expectedPrefix));
+      return m.substring(expectedPrefix.length()).replaceFirst("\nfull actual.*", "");
+    }
+  }
+
+  private static String jsonSubsetFailureMessage(String expected, String actual) {
+    try {
+      assertJsonSubset(expected, actual);
+      fail("expected AssertionFailedException");
+      return null;
+    } catch (AssertionError e) {
+      String m = e.getMessage();
+      String expectedPrefix = "JSON string did not contain expected properties\n";
+      assertThat(m, startsWith(expectedPrefix));
+      return m.substring(expectedPrefix.length()).replaceFirst("\nfull actual.*", "");
+    }
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/JsonAssertionsTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/JsonAssertionsTest.java
@@ -1,112 +1,202 @@
 package com.launchdarkly.testhelpers;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 
 import static com.launchdarkly.testhelpers.JsonAssertions.assertJsonEquals;
-import static com.launchdarkly.testhelpers.JsonAssertions.assertJsonSubset;
+import static com.launchdarkly.testhelpers.JsonAssertions.assertJsonIncludes;
+import static com.launchdarkly.testhelpers.JsonAssertions.isJsonArray;
+import static com.launchdarkly.testhelpers.JsonAssertions.jsonEquals;
+import static com.launchdarkly.testhelpers.JsonAssertions.jsonEqualsValue;
+import static com.launchdarkly.testhelpers.JsonAssertions.jsonIncludes;
+import static com.launchdarkly.testhelpers.JsonAssertions.jsonNull;
+import static com.launchdarkly.testhelpers.JsonAssertions.jsonProperty;
+import static com.launchdarkly.testhelpers.JsonAssertions.jsonUndefined;
+import static com.launchdarkly.testhelpers.JsonTestValue.jsonOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyIterable;
 
 @SuppressWarnings("javadoc")
 public class JsonAssertionsTest {
   @Test
   public void assertJsonEqualsSuccess() {
-    assertJsonEquals("null", "null");
-    assertJsonEquals("true", "true");
-    assertJsonEquals("1", "1");
-    assertJsonEquals("\"x\"", "\"x\"");
-    assertJsonEquals("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2},\"a\":1}");
-    assertJsonEquals("[1,2,[3,4]]","[1,2,[3,4]]");
+    jsonEqualsShouldSucceed("null", "null");
+    jsonEqualsShouldSucceed("true", "true");
+    jsonEqualsShouldSucceed("1", "1");
+    jsonEqualsShouldSucceed("\"x\"", "\"x\"");
+    jsonEqualsShouldSucceed("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2},\"a\":1}");
+    jsonEqualsShouldSucceed("[1,2,[3,4]]","[1,2,[3,4]]");
+    
+    assertThat(jsonOf("true"), jsonEqualsValue(true));
+  }
+  
+  private static void jsonEqualsShouldSucceed(String expected, String actual) {
+    assertJsonEquals(expected, actual);
+    assertThat(jsonOf(actual), jsonEquals(jsonOf(expected)));
+    assertThat(jsonOf(actual), jsonEquals(expected));
   }
   
   @Test
   public void assertJsonEqualsFailureWithNoDetailedDiff() {
-    assertThat(jsonEqualsFailureMessage("null", "true"),
-        equalTo("expected: null\nactual: true"));
-    assertThat(jsonEqualsFailureMessage("false", "true"),
-        equalTo("expected: false\nactual: true"));
-    assertThat(jsonEqualsFailureMessage("{\"a\":1}", "3"),
-        equalTo("expected: {\"a\":1}\nactual: 3"));
-    assertThat(jsonEqualsFailureMessage("[1,2]", "3"),
-        equalTo("expected: [1,2]\nactual: 3"));
-    assertThat(jsonEqualsFailureMessage("[1,2]", "[1,2,3]"),
-        equalTo("expected: [1,2]\nactual: [1,2,3]"));
+    jsonEqualsShouldFail("null", null, "no value");
+    jsonEqualsShouldFail("null", "{", "not valid JSON");
+    jsonEqualsShouldFail("null", "true", "expected: null\nactual: true");
+    jsonEqualsShouldFail("false", "true", "expected: false\nactual: true");
+    jsonEqualsShouldFail("{\"a\":1}", "3", "expected: {\"a\":1}\nactual: 3");
+    jsonEqualsShouldFail("[1,2]", "3", "expected: [1,2]\nactual: 3");
+    jsonEqualsShouldFail("[1,2]", "[1,2,3]", "expected: [1,2]\nactual: [1,2,3]");
   }
 
   @Test
   public void assertJsonEqualsFailureWithDetailedDiff() {
-    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":2}", "{\"a\":1,\"b\":3}"),
-        equalTo("at \"b\": expected = 2, actual = 3"));
+    jsonEqualsShouldFail("{\"a\":1,\"b\":2}", "{\"a\":1,\"b\":3}",
+        "at \"b\": expected = 2, actual = 3");
 
-    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":2}", "{\"a\":1}"),
-        equalTo("at \"b\": expected = 2, actual = <absent>"));
+    jsonEqualsShouldFail("{\"a\":1,\"b\":2}", "{\"a\":1}",
+        "at \"b\": expected = 2, actual = <absent>");
 
-    assertThat(jsonEqualsFailureMessage("{\"a\":1}", "{\"a\":1,\"b\":2}"),
-        equalTo("at \"b\": expected = <absent>, actual = 2"));
+    jsonEqualsShouldFail("{\"a\":1}", "{\"a\":1,\"b\":2}",
+        "at \"b\": expected = <absent>, actual = 2");
 
-    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":{\"c\":2}}", "{\"a\":1,\"b\":{\"c\":3}}"),
-        equalTo("at \"b.c\": expected = 2, actual = 3"));
+    jsonEqualsShouldFail("{\"a\":1,\"b\":{\"c\":2}}", "{\"a\":1,\"b\":{\"c\":3}}",
+        "at \"b.c\": expected = 2, actual = 3");
 
-    assertThat(jsonEqualsFailureMessage("{\"a\":1,\"b\":[2,3]}", "{\"a\":1,\"b\":[3,3]}"),
-        equalTo("at \"b[0]\": expected = 2, actual = 3"));
+    jsonEqualsShouldFail("{\"a\":1,\"b\":[2,3]}", "{\"a\":1,\"b\":[3,3]}",
+        "at \"b[0]\": expected = 2, actual = 3");
 
-    assertThat(jsonEqualsFailureMessage("[100,200,300]", "[100,201,300]"),
-        equalTo("at \"[1]\": expected = 200, actual = 201"));
+    jsonEqualsShouldFail("[100,200,300]", "[100,201,300]",
+        "at \"[1]\": expected = 200, actual = 201");
 
-    assertThat(jsonEqualsFailureMessage("[100,[200,210],300]", "[100,[201,210],300]"),
-        equalTo("at \"[1][0]\": expected = 200, actual = 201"));
+    jsonEqualsShouldFail("[100,[200,210],300]", "[100,[201,210],300]",
+        "at \"[1][0]\": expected = 200, actual = 201");
 
-    assertThat(jsonEqualsFailureMessage("[100,{\"a\":1},300]", "[100,{\"a\":2},300]"),
-        equalTo("at \"[1].a\": expected = 1, actual = 2"));
+    jsonEqualsShouldFail("[100,{\"a\":1},300]", "[100,{\"a\":2},300]",
+        "at \"[1].a\": expected = 1, actual = 2");
+  }
+  
+  private static void jsonEqualsShouldFail(String expected, String actual, String expectedMessage) {
+    assertThat(() -> assertJsonEquals(expected, actual),
+        shouldFailWithMessage(Matchers.containsString(expectedMessage)));
+    assertThat(() -> assertThat(jsonOf(actual), jsonEquals(jsonOf(expected))),
+        shouldFailWithMessage(Matchers.containsString(expectedMessage)));
   }
   
   @Test
-  public void assertJsonSubsetSuccess() {
-   assertJsonSubset("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1}");
-   assertJsonSubset("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1,\"c\":3}");
-   assertJsonSubset("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2,\"d\":3},\"a\":1}");
+  public void assertJsonIncludesSuccess() {
+    jsonIncludesShouldSucceed("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1}");
+    jsonIncludesShouldSucceed("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1,\"c\":3}");
+    jsonIncludesShouldSucceed("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2,\"d\":3},\"a\":1}");
+  }
+
+  private void jsonIncludesShouldSucceed(String expected, String actual) {
+    assertJsonIncludes(expected, actual);
+    assertThat(jsonOf(actual), jsonIncludes(jsonOf(expected)));
+    assertThat(jsonOf(actual), jsonIncludes(expected));
   }
   
   @Test
-  public void assertJsonSubsetFailure() {
-    assertThat(jsonSubsetFailureMessage("{\"a\":1}", "{\"a\":0,\"b\":2,\"c\":3}"),
-        equalTo("at \"a\": expected = 1, actual = 0"));
+  public void assertJsonIncludesFailure() {
+    jsonIncludesShouldFail("null", null, "no value");
+    jsonIncludesShouldFail("null", "{", "not valid JSON");
 
-    assertThat(jsonSubsetFailureMessage("{\"a\":1}", "{\"b\":2,\"c\":3}"),
-        equalTo("at \"a\": expected = 1, actual = <absent>"));
+    jsonIncludesShouldFail("{\"a\":1}", "{\"a\":0,\"b\":2,\"c\":3}",
+        "at \"a\": expected = 1, actual = 0");
 
-    assertThat(jsonSubsetFailureMessage("{\"b\":2,\"a\":1,\"c\":3}", "{\"a\":1,\"b\":2}"),
-        equalTo("at \"c\": expected = 3, actual = <absent>"));
+    jsonIncludesShouldFail("{\"a\":1}", "{\"b\":2,\"c\":3}",
+        "at \"a\": expected = 1, actual = <absent>");
 
-    assertThat(jsonSubsetFailureMessage("{\"b\":{\"c\":2,\"d\":3},\"a\":1}", "{\"a\":1,\"b\":{\"c\":2}}"),
-        equalTo("at \"b.d\": expected = 3, actual = <absent>"));
+    jsonIncludesShouldFail("{\"b\":2,\"a\":1,\"c\":3}", "{\"a\":1,\"b\":2}",
+        "at \"c\": expected = 3, actual = <absent>");
+
+    jsonIncludesShouldFail("{\"b\":{\"c\":2,\"d\":3},\"a\":1}", "{\"a\":1,\"b\":{\"c\":2}}",
+        "at \"b.d\": expected = 3, actual = <absent>");
+  }
+
+  private static void jsonIncludesShouldFail(String expected, String actual, String expectedMessage) {
+    assertThat(() -> assertJsonIncludes(expected, actual),
+        shouldFailWithMessage(Matchers.containsString(expectedMessage)));
+    assertThat(() -> assertThat(jsonOf(actual), jsonIncludes(expected)),
+        shouldFailWithMessage(Matchers.containsString(expectedMessage)));
   }
   
-  private static String jsonEqualsFailureMessage(String expected, String actual) {
-    try {
-      assertJsonEquals(expected, actual);
-      fail("expected AssertionFailedException");
-      return null;
-    } catch (AssertionError e) {
-      String m = e.getMessage();
-      String expectedPrefix = "JSON strings did not match\n";
-      assertThat(m, startsWith(expectedPrefix));
-      return m.substring(expectedPrefix.length()).replaceFirst("\nfull actual.*", "");
-    }
-  }
+  @Test
+  public void jsonPropertySuccess() {
+    assertThat(jsonOf("{\"a\":true}"), jsonProperty("a", jsonEquals("true")));
+    assertThat(jsonOf("{\"a\":true}"), jsonProperty("a", true));
 
-  private static String jsonSubsetFailureMessage(String expected, String actual) {
-    try {
-      assertJsonSubset(expected, actual);
-      fail("expected AssertionFailedException");
-      return null;
-    } catch (AssertionError e) {
-      String m = e.getMessage();
-      String expectedPrefix = "JSON string did not contain expected properties\n";
-      assertThat(m, startsWith(expectedPrefix));
-      return m.substring(expectedPrefix.length()).replaceFirst("\nfull actual.*", "");
-    }
+    assertThat(jsonOf("{\"a\":1}"), jsonProperty("a", 1));
+    assertThat(jsonOf("{\"a\":2.5}"), jsonProperty("a", 2.5));
+    assertThat(jsonOf("{\"a\":\"x\"}"), jsonProperty("a", "x"));
+
+    assertThat(jsonOf("{\"a\":{\"b\": 1}}"), jsonProperty("a", jsonProperty("b", 1)));
+    
+    assertThat(jsonOf("{\"a\":true}"), jsonProperty("b", jsonUndefined()));
+    assertThat(jsonOf("{\"a\":null}"), jsonProperty("a", jsonNull()));
+  }
+  
+  @Test
+  public void jsonPropertyFailure() {
+    assertThat(() -> assertThat(jsonOf(null), jsonProperty("a", true)),
+        shouldFailWithMessage(containsString("no value")));
+
+    assertThat(() -> assertThat(jsonOf("[]"), jsonProperty("a", true)),
+        shouldFailWithMessage(containsString("not a JSON object")));
+
+    assertThat(() -> assertThat(jsonOf("{\"a\":1}"), jsonProperty("b", 1)),
+        shouldFailWithMessage(Matchers.allOf(containsString("Expected: property \"b\""), containsString("no value"))));
+
+    assertThat(() -> assertThat(jsonOf("{\"a\":1}"), jsonProperty("a", 2)),
+        shouldFailWithMessage(Matchers.allOf(containsString("Expected: property \"a\""), containsString("actual: 1"))));
+}
+  
+  @SuppressWarnings("unchecked")
+  @Test
+  public void isJsonArraySuccess() {
+    assertThat(jsonOf("[]"), isJsonArray(emptyIterable()));
+    assertThat(jsonOf("[true]"), isJsonArray(contains(jsonEqualsValue(true))));
+    assertThat(jsonOf("[true, false]"), isJsonArray(contains(jsonEqualsValue(true), jsonEqualsValue(false))));
+  }
+  
+  @Test
+  public void isJsonArrayFailure() {
+    assertThat(() -> assertThat(jsonOf(null), isJsonArray(emptyIterable())),
+        shouldFailWithMessage(containsString("no value")));
+
+    assertThat(() -> assertThat(jsonOf("{}"), isJsonArray(emptyIterable())),
+        shouldFailWithMessage(containsString("not a JSON array")));
+       
+    assertThat(() -> assertThat(jsonOf("[true]"), isJsonArray(contains(jsonEqualsValue(false)))),
+        shouldFailWithMessage(containsString("item 0: expected: false\nactual: true")));
+  }
+  
+  private static Matcher<Runnable> shouldFailWithMessage(Matcher<String> matcher) {
+    return new TypeSafeDiagnosingMatcher<Runnable>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("should fail with message:");
+        matcher.describeTo(description);
+      }
+
+      @Override
+      protected boolean matchesSafely(Runnable item, Description mismatchDescription) {
+        try {
+          item.run();
+          mismatchDescription.appendText("did not throw exception");
+          return false;
+        } catch (AssertionError e) {
+          String message = e.getMessage().trim();
+          if (!matcher.matches(message)) {
+            matcher.describeMismatch(message, mismatchDescription);
+            return false;
+          }
+          return true;
+        }
+      }
+    };
   }
 }

--- a/src/test/java/com/launchdarkly/testhelpers/JsonTestValueTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/JsonTestValueTest.java
@@ -1,0 +1,69 @@
+package com.launchdarkly.testhelpers;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import org.junit.Test;
+
+import static com.launchdarkly.testhelpers.AssertionsTest.requireAssertionError;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@SuppressWarnings("javadoc")
+public class JsonTestValueTest {
+  @Test
+  public void parseUndefined() {
+    JsonTestValue v = JsonTestValue.jsonOf(null);
+    assertThat(v, notNullValue());
+    assertThat(v.isDefined(), equalTo(false));
+    assertThat(v.raw, nullValue());
+    assertThat(v.parsed, nullValue());
+  }
+  
+  @Test
+  public void parseMalformed() {
+    assertThat(requireAssertionError(() -> JsonTestValue.jsonOf("{no")),
+        allOf(containsString("not valid JSON"), containsString("{no")));
+  }
+  
+  @Test
+  public void parseSuccess() {
+    JsonTestValue v = JsonTestValue.jsonOf("123");
+    assertThat(v, notNullValue());
+    assertThat(v.isDefined(), equalTo(true));
+    assertThat(v.raw, equalTo("123"));
+    assertThat(v.parsed, equalTo(new JsonPrimitive(123)));
+  }
+  
+  @Test
+  public void fromParsedUndefined() {
+    JsonTestValue v = JsonTestValue.ofParsed(null);
+    assertThat(v, notNullValue());
+    assertThat(v.isDefined(), equalTo(false));
+    assertThat(v.raw, nullValue());
+    assertThat(v.parsed, nullValue());
+  }
+  
+  @Test
+  public void fromParsedValue() {
+    JsonElement parsed = new JsonPrimitive(123);
+    JsonTestValue v = JsonTestValue.ofParsed(parsed);
+    assertThat(v, notNullValue());
+    assertThat(v.isDefined(), equalTo(true));
+    assertThat(v.raw, equalTo("123"));
+    assertThat(v.parsed, equalTo(parsed));
+  }
+  
+  @Test
+  public void fromValue() {
+    JsonTestValue v = JsonTestValue.jsonFromValue(true);
+    assertThat(v, notNullValue());
+    assertThat(v.isDefined(), equalTo(true));
+    assertThat(v.raw, equalTo("true"));
+    assertThat(v.parsed, equalTo(new JsonPrimitive(true)));
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/TempDirTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/TempDirTest.java
@@ -1,0 +1,48 @@
+package com.launchdarkly.testhelpers;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+@SuppressWarnings("javadoc")
+public class TempDirTest {
+  @Test
+  public void tempDir() {
+    Path path = null;
+    try (TempDir dir = TempDir.create()) {
+      path = dir.getPath();
+      assertThat(Files.isDirectory(path), is(true));
+      
+      TempFile f1 = dir.tempFile();
+      assertThat(Files.isRegularFile(f1.getPath()), is(true));
+      assertThat(f1.getPath().toString(), startsWith(path.toString()));
+
+      TempFile f2 = dir.tempFile(".x");
+      assertThat(Files.isRegularFile(f2.getPath()), is(true));
+      assertThat(f2.getPath().toString(), startsWith(path.toString()));
+      assertThat(f2.getPath().toString(), endsWith(".x"));
+    }
+    assertThat(Files.exists(path), is(false));
+  }
+
+  @Test
+  public void canDeleteTempDirBeforeClosing() {
+    Path path = null;
+    try (TempDir dir = TempDir.create()) {
+      path = dir.getPath();
+      assertThat(Files.isDirectory(path), is(true));
+     
+      dir.tempFile("");
+      
+      dir.delete();
+      assertThat(Files.exists(path), is(false));
+    }
+    assertThat(Files.exists(path), is(false));
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/TempFileTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/TempFileTest.java
@@ -1,0 +1,55 @@
+package com.launchdarkly.testhelpers;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("javadoc")
+public class TempFileTest {
+  @Test
+  public void tempFile() throws Exception {
+    Path path = null;
+    try (TempFile file = TempFile.create()) {
+      path = file.getPath();
+      assertThat(Files.isRegularFile(path), is(true));
+      
+      assertThat(Files.readString(path), equalTo(""));
+
+      file.setContents("xyz");
+      
+      assertThat(Files.readString(path), equalTo("xyz"));
+    }
+    assertThat(Files.exists(path), is(false));
+  }
+
+  @Test
+  public void tempFileWithSuffix() throws Exception {
+    Path path = null;
+    try (TempFile file = TempFile.create(".x")) {
+      path = file.getPath();
+      assertThat(Files.isRegularFile(path), is(true));
+      assertThat(path.toString(), endsWith(".x"));
+    }
+    assertThat(Files.exists(path), is(false));
+  }
+
+  @Test
+  public void canDeleteTempFileBeforeClosing() throws Exception {
+    Path path = null;
+    try (TempFile file = TempFile.create()) {
+      path = file .getPath();
+      assertThat(Files.isRegularFile(path), is(true));
+     
+      file.delete();
+
+      assertThat(Files.exists(path), is(false));
+    }
+    assertThat(Files.exists(path), is(false));
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/TempFileTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/TempFileTest.java
@@ -19,11 +19,11 @@ public class TempFileTest {
       path = file.getPath();
       assertThat(Files.isRegularFile(path), is(true));
       
-      assertThat(Files.readString(path), equalTo(""));
+      assertThat(new String(Files.readAllBytes(path)), equalTo(""));
 
       file.setContents("xyz");
       
-      assertThat(Files.readString(path), equalTo("xyz"));
+      assertThat(new String(Files.readAllBytes(path)), equalTo("xyz"));
     }
     assertThat(Files.exists(path), is(false));
   }
@@ -43,7 +43,7 @@ public class TempFileTest {
   public void canDeleteTempFileBeforeClosing() throws Exception {
     Path path = null;
     try (TempFile file = TempFile.create()) {
-      path = file .getPath();
+      path = file.getPath();
       assertThat(Files.isRegularFile(path), is(true));
      
       file.delete();

--- a/src/test/java/com/launchdarkly/testhelpers/TypeBehaviorTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/TypeBehaviorTest.java
@@ -1,0 +1,170 @@
+package com.launchdarkly.testhelpers;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.launchdarkly.testhelpers.TypeBehavior.checkEqualsAndHashCode;
+import static com.launchdarkly.testhelpers.TypeBehavior.valueFactoryFromInstances;
+
+@SuppressWarnings("javadoc")
+public class TypeBehaviorTest {
+  @Test
+  public void checkEqualsAndHashCodeSuccess() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            valueFactoryFromInstances(
+                new TypeWithValueAndHashCode("a", 1),
+                new TypeWithValueAndHashCode("a", 1)),            
+            valueFactoryFromInstances(
+                new TypeWithValueAndHashCode("b", 2),
+                new TypeWithValueAndHashCode("b", 2)),            
+            valueFactoryFromInstances(
+                new TypeWithValueAndHashCode("c", 2),
+                new TypeWithValueAndHashCode("c", 2)) // hash codes deliberately the same as b - that is allowed             
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForIncorrectEquality() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            () -> new TypeThatEqualsEveryObjectAndAlwaysHasSameHashCode(),
+            () -> new TypeThatEqualsEveryObjectAndAlwaysHasSameHashCode()
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForEqualingNull() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            () -> new TypeThatEqualsEveryObjectOrNullAndAlwaysHasSameHashCode()
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForIncorrectInequality() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            () -> new TypeThatEqualsOnlyItself()
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForObjectNotEqualingItself() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            () -> new TypeThatEqualsNothing()
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForNonTransitiveEquality() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            valueFactoryFromInstances(
+                new TypeThatEqualsSameOrHigherValue(1),
+                new TypeThatEqualsSameOrHigherValue(2)
+                )
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForNonTransitiveInequality() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            valueFactoryFromInstances(
+                new TypeThatEqualsSameOrHigherValue(1),
+                new TypeThatEqualsSameOrHigherValue(1)),
+            valueFactoryFromInstances(
+                new TypeThatEqualsSameOrHigherValue(2),
+                new TypeThatEqualsSameOrHigherValue(2))
+            ));
+  }
+
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForInconsistentHashCode() {
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            valueFactoryFromInstances(
+                new TypeWithValueAndHashCode("a", 1),
+                new TypeWithValueAndHashCode("a", 2))
+            ));
+  }
+  
+  private static class TypeWithValueAndHashCode {
+    private final String value;
+    private final int hashCode;
+    
+    public TypeWithValueAndHashCode(String value, int hashCode) {
+      this.value = value;
+      this.hashCode = hashCode;
+    }
+    
+    public boolean equals(Object o) {
+      return o instanceof TypeWithValueAndHashCode &&
+          ((TypeWithValueAndHashCode)o).value.equals(this.value);
+    }
+    
+    public int hashCode() {
+      return this.hashCode;
+    }
+    
+    public String toString() {
+      return value + "/" + hashCode;
+    }
+  }
+  
+  private static class TypeThatEqualsEveryObjectAndAlwaysHasSameHashCode {
+    public boolean equals(Object o) {
+      return o != null;
+    }
+    
+    public int hashCode() {
+      return 1;
+    }
+  }
+
+  private static class TypeThatEqualsEveryObjectOrNullAndAlwaysHasSameHashCode {
+    public boolean equals(Object o) {
+      return true;
+    }
+    
+    public int hashCode() {
+      return 1;
+    }
+  }
+  
+  private static class TypeThatEqualsOnlyItself {
+    public boolean equals(Object o) {
+      return this == o;
+    }
+    
+    public int hashCode() {
+      return 1;
+    }
+  }
+  
+  private static class TypeThatEqualsNothing {
+    public boolean equals(Object o) {
+      return false;
+    }
+    
+    public int hashCode() {
+      return 1;
+    }
+  }
+  
+  private static class TypeThatEqualsSameOrHigherValue {
+    private final int index;
+    
+    TypeThatEqualsSameOrHigherValue(int index) {
+      this.index = index;
+    }
+    
+    public boolean equals(Object o) {
+      return o instanceof TypeThatEqualsSameOrHigherValue &&
+             ((TypeThatEqualsSameOrHigherValue)o).index >= this.index;
+    }
+  }
+}


### PR DESCRIPTION
This adds a bunch of other reusable test code based on things we've implemented before in multiple Java projects.

In most cases, this is just for the sake of DRY. However, there are a couple other benefits of having these.

(1) For making assertions about JSON data, which there is a lot of in the SDK, we had previously been using a variety of approaches:
* Parsing the JSON into a Gson `JsonElement` and using its deep-equality implementation of `equals()`.
* Doing the same, but with `LDValue` instead of the Gson type.
* Parsing the JSON into some other temporary data structure using reflection.
* Doing substring searches of the JSON.
* Implementing custom Hamcrest matches that operated on a `JsonElement` or an `LDValue`.

These approaches cluttered up the tests with a lot of irrelevant implementation details, and also tended not to provide very useful failure output (e.g. if an equality test failed on a big object because one property was wrong, you'd get a dump of the whole thing and have to look through it to find the problem).

The `JsonAssertions` helpers provide simple assertions with much better error output, but also Hamcrest matchers which let you write things like `assertThat(jsonOf("<some JSON string>"), jsonProperty("on", jsonEqualsValue(true))))`. Using the latter makes tests more type-safe (clarifying when a string is really a JSON value versus just a string, and failing fast if it's not valid JSON) and also lets you use Hamcrest combinators to say things like "the property could be either null or absent".

(2) The `TypeBehavior` class provides a test suite for validating the behavior of `equals` and `hashCode` in any types where we've overridden those methods. It's easy in Java to miss some detail so that for instance `equals` doesn't return false negatives but does return false positives, or `equals(null)` wrongly returns true, etc. Using this test suite enforces correctness without having to write very repetitive tests.

Note about the use of `TimeUnit`: for timing-related tests, I deliberately used `long, TimeUnit` parameter pairs instead of the more convenient `java.time.Duration`. That's because I'm still hoping to make this library Android-compatible in the near future, and you can't have any references to `Duration` in Android code.