### PR TITLE
use hamcrest-library rather than hamcrest-all, to avoid conflicts with junit transitive dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation("com.google.code.gson:gson:${Versions.gson}")
     implementation("com.google.guava:guava:${Versions.guava}")
     implementation("com.squareup.okhttp3:okhttp-tls:${Versions.okhttpTls}")
-    implementation("org.hamcrest:hamcrest-all:1.3")
+    implementation("org.hamcrest:hamcrest-library:1.3")
 
     testImplementation("ch.qos.logback:logback-classic:1.1.9")
     testImplementation("com.squareup.okhttp3:okhttp:4.5.0")


### PR DESCRIPTION
The unit testing libraries JUnit and Hamcrest are used by all of our Java projects, and `java-test-helpers` includes some helpers that are specifically for use with Hamcrest, so it deliberately exposes a dependency on Hamcrest.

However... Hamcrest unfortunately has a confusing distribution in which you can either 1. get some of the classes from the artifact `hamcrest-core` and others from the artifact `hamcrest-library`, or 2. get them all in one with `hamcrest-all`. Currently we are using `hamcrest-all`. But that is a problem because JUnit has a transitive dependency on `hamcrest-core`, so the classes in that artifact will be loaded twice, once from `hamcrest-core` and once from `hamcrest-all` (Maven and Gradle deduplicate artifacts, not classes).

Duplicate classes are not necessarily a huge deal in Java if they are the same version of the same code, but they're a big no-no for any code we need to run in Android, so that has required us to add some "exclude transitive Hamcrest dependency" directives in our Android builds when we use `java-test-helpers`.

I believe the right solution is just to use `hamcrest-library` as the dependency here, and make sure our own projects similarly use that artifact instead of `hamcrest-all`, since we do not have control over JUnit's transitive dependency.

(In JUnit 5, this becomes a non-issue because JUnit 5 does not have a dependency on Hamcrest. But we can't adopt JUnit 5 yet in any projects that can be used in Android, because we are currently supporting old Android versions that aren't compatible with Java 8 and JUnit 5 requires Java 8.)