### PR TITLE
allow use of a singleton factory with TypeBehavior.checkEqualsAndHashCode

### DIFF
--- a/src/main/java/com/launchdarkly/testhelpers/TypeBehavior.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TypeBehavior.java
@@ -72,9 +72,6 @@ public abstract class TypeBehavior {
       for (int j = 0; j < valueFactories.size(); j++) {
         T value1 = valueFactories.get(i).get();
         T value2 = valueFactories.get(j).get();
-        if (value1 == value2) {
-          throw new AssertionError("value factory must not return the same instance twice");
-        }
         if (i == j) {
           // instance is equal to itself
           if (!value1.equals(value1)) {

--- a/src/main/java/com/launchdarkly/testhelpers/TypeBehavior.java
+++ b/src/main/java/com/launchdarkly/testhelpers/TypeBehavior.java
@@ -23,6 +23,18 @@ public abstract class TypeBehavior {
     T get();
   }
   
+  private static class SingletonValueFactory<T> implements ValueFactory<T> {
+    private final T value;
+    
+    SingletonValueFactory(T value) {
+      this.value = value;
+    }
+    
+    public T get() {
+      return value;
+    }
+  }
+  
   /**
    * Creates a simple {@link ValueFactory} that returns the specified instances in order
    * each time it is called. After all instances are used, it starts over at the first.
@@ -45,6 +57,22 @@ public abstract class TypeBehavior {
   }
   
   /**
+   * Creates a simple {@link ValueFactory} that returns the sameinstance each time it
+   * is called. After all instances are used, it starts over at the first. This is for use
+   * with {@link #checkEqualsAndHashCode(List)}, and you should use it instead of
+   * a lambda like {@code () -> value} whenever the type enforces singleton usage, because
+   * otherwise {@link #checkEqualsAndHashCode(List)} will expect the return values to be
+   * equal only value and <i>not</i> by reference.
+   * 
+   * @param <T> the value type
+   * @param value the instance
+   * @return a value factory
+   */
+  public static <T> ValueFactory<T> singletonValueFactory(T value) {
+    return new SingletonValueFactory<>(value);
+  }
+  
+  /**
    * Implements a standard test suite for custom implementations of {@code equals()} and
    * {@code hashCode()}.
    * <p>
@@ -62,7 +90,12 @@ public abstract class TypeBehavior {
    * {@code a.equals(b)} and {@code b.equals(a)} are false (there is no requirement that
    * the hash codes are different). </li>
    * </ul>
-   * 
+   * <p>
+   * If the type uses a singleton/interning pattern so that there can only be one
+   * instance with a particular value, use {@link #singletonValueFactory(Object)} to
+   * indicate that that is deliberate; otherwise {@link #checkEqualsAndHashCode(List)}
+   * will assume that it is a test logic error if it sees the same instance twice. 
+   *
    * @param <T> the value type
    * @param valueFactories list of factories for distinct values
    * @throws AssertionError if a test condition fails
@@ -73,35 +106,57 @@ public abstract class TypeBehavior {
         T value1 = valueFactories.get(i).get();
         T value2 = valueFactories.get(j).get();
         if (i == j) {
-          // instance is equal to itself
+          // Here, value1 and value2 are from the same value factory, so we expect them to be equal,
+          // as follows:
+          // 1. An instance must be equal to itself.
           if (!value1.equals(value1)) {
             throw new AssertionError("value was not equal to itself: " + value1);
           }
  
-          // commutative equality
-          if (!value1.equals(value2)) {
-            throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was false");
+          // In normal usage of checkEqualsAndHashCode, we're testing for value equality (and
+          // consistent hashing by value) between different instances of T that have the same
+          // properties, so value1 and value2 should *not* be the exact same object. However,
+          // some types use a singleton or interning pattern where it's not possible to have
+          // multiple instances with the same properties; if so, the test logic should tell us
+          // this by explicitly using singletonValueFactory, and then we will skip that check
+          // as well as other tests that are for multiple instances (2 & 3 below).
+          if (!(valueFactories.get(i) instanceof SingletonValueFactory<?>)) {
+              if (value1 == value2) {
+                throw new AssertionError("value factory for checkEqualsAndHashCode returned the same"
+                    + " instance twice in a row; if this is intentionally a singleton, you must use"
+                    + " TypeBehavior.singletonValueFactory");
+              }
+   
+            // 2. Commutative equality: value1.equals(value2) and value2.equals(value1) must
+            // both be true.
+            if (!value1.equals(value2)) {
+              throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was false");
+            }
+            if (!value2.equals(value1)) {
+              throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was true, but (" +
+                  value2 + ").equals(" + value1 + ") was false");
+            }
+   
+            // 3. The hashCodes for two logically equal instances must be equal.
+            if (value1.hashCode() != value2.hashCode()) {
+              throw new AssertionError("(" + value1 + ").hashCode() was " + value1.hashCode() + " but ("
+                  + value2 + ").hashCode() was " + value2.hashCode());
+            }
           }
-          if (!value2.equals(value1)) {
-            throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was true, but (" +
-                value2 + ").equals(" + value1 + ") was false");
-          }
- 
-          // equal hash code
-          if (value1.hashCode() != value2.hashCode()) {
-            throw new AssertionError("(" + value1 + ").hashCode() was " + value1.hashCode() + " but ("
-                + value2 + ").hashCode() was " + value2.hashCode());
-          }
- 
-          // unequal to null, unequal to value of wrong class
+          
+          // 4. An instance of anything is always unequal to null.
           if (value1.equals(null)) {
             throw new AssertionError("value was equal to null: " + value1);
           }
+          // 5. An instance of T is always unequal to an instance of a class that isn't T. 
           if (value1.equals(new Object())) {
             throw new AssertionError("value was equal to Object: " + value1);
           }
         } else {
-          // commutative inequality
+          // Here, value1 and value2 are not from the same factory, so we expect them to be
+          // unequal (regardless of which one we call equals on). Note that we do *not* have a
+          // similar test for the hashCodes being unequal, because that's not a requirement in
+          // Java-- collisions are allowed.
           if (value1.equals(value2)) {
             throw new AssertionError("(" + value1 + ").equals(" + value2 + ") was true");
           }

--- a/src/test/java/com/launchdarkly/testhelpers/TypeBehaviorTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/TypeBehaviorTest.java
@@ -92,6 +92,28 @@ public class TypeBehaviorTest {
             ));
   }
   
+  @Test(expected=AssertionError.class)
+  public void checkEqualsAndHashCodeFailureForSameInstanceSeenTwice() {
+    TypeThatEqualsOnlyItself instance1 = new TypeThatEqualsOnlyItself();
+    TypeThatEqualsOnlyItself instance2 = new TypeThatEqualsOnlyItself();
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            () -> instance1,
+            () -> instance2
+            ));
+  }
+
+  @Test
+  public void checkEqualsAndHashCodeAllowsSingletonPattern() {
+    TypeThatEqualsOnlyItself instance1 = new TypeThatEqualsOnlyItself();
+    TypeThatEqualsOnlyItself instance2 = new TypeThatEqualsOnlyItself();
+    checkEqualsAndHashCode(
+        Arrays.asList(
+            TypeBehavior.singletonValueFactory(instance1),
+            TypeBehavior.singletonValueFactory(instance2)
+            ));
+  }
+
   private static class TypeWithValueAndHashCode {
     private final String value;
     private final int hashCode;


### PR DESCRIPTION
This helper method is a shortcut for checking that equals() and hashCode() behave as expected for various possible instances of a type. It takes a list of factory objects or lambdas, like this—

```java
  TypeBehavior.checkEqualsAndHashCode(
    () -> new Thingy("x", 1),
    () -> new Thingy("x", 2),
    () -> new Thingy("y", 1));
```

—the rationale being that we want to make sure `new Thingy("x", 1)` is equal to another instance with the same properties (from calling the same factory lambda), as well as being unequal to other instances with different properties. However... this is problematic for a type like EvaluationReason, where some of the values are singletons/interned:

```java
  TypeBehavior.checkEqualsAndHashCode(
    () -> EvaluationReason.off(),
    () -> EvaluationReason.ruleMatch(1, "id"));
```

The problem is that `EvaluationReason.off()` deliberately always returns the same immutable instance, and `checkEqualsAndHashCode` currently has a rule that the instances can't be literally the same, because then we don't know if we are really testing value equality or just reference equality. So, this PR adds a new way to clarify this:

```java
  TypeBehavior.checkEqualsAndHashCode(
    TypeBehavior.singletonValueFactory(EvaluationReason.off()),
    () -> EvaluationReason.ruleMatch(1, "id"));
  }
```

This tells it that we know `EvaluationReason.off()` is always the same instance, so we only need to check that it is equal to itself (and unequal to null or to something of the wrong class), whereas the `ruleMatch` one will be multiple instances so we will also want to do the commutative equality and hash code equality tests.