### PR TITLE
add simple TCP listener helpers

### DIFF
--- a/src/main/java/com/launchdarkly/testhelpers/httptest/Handlers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/httptest/Handlers.java
@@ -1,5 +1,7 @@
 package com.launchdarkly.testhelpers.httptest;
 
+import com.launchdarkly.testhelpers.tcptest.TcpServer;
+
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.util.Callback;
 
@@ -235,7 +237,12 @@ public abstract class Handlers {
    * of client logic that needs to handle exceptions differently from HTTP error statuses.
    *  
    * @return a {@link Handler}
+   * @deprecated This method is deprecated because the mechanism for forcing the HTTP server to
+   * close the connection early is fragile and relies on implementation details of the
+   * underlying server framework. A more reliable approach is to use a {@link TcpServer} instead
+   * of an {@link HttpServer}, and configure it to close the connection without a response.
    */
+  @Deprecated
   public static Handler malformedResponse() {
     return ctx -> {
       HttpConnection conn = HttpConnection.getCurrentConnection();

--- a/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandler.java
+++ b/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandler.java
@@ -1,0 +1,19 @@
+package com.launchdarkly.testhelpers.tcptest;
+
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * Use with {@link TcpServer} to define behavior for a TCP endpoint in a test.
+ * 
+ * @since 2.0.0
+ */
+public interface TcpHandler {
+  /**
+   * Processes the request.
+   * 
+   * @param socket the incoming socket
+   * @throws IOException for any I/O error
+   */
+  void apply(Socket socket) throws IOException;
+}

--- a/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandler.java
+++ b/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandler.java
@@ -6,7 +6,7 @@ import java.net.Socket;
 /**
  * Use with {@link TcpServer} to define behavior for a TCP endpoint in a test.
  * 
- * @since 2.0.0
+ * @since 1.3.0
  */
 public interface TcpHandler {
   /**

--- a/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandlers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandlers.java
@@ -1,0 +1,135 @@
+package com.launchdarkly.testhelpers.tcptest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Factory methods for standard {@link TcpHandler} implementations.
+ */
+public abstract class TcpHandlers {
+  private TcpHandlers() {}
+
+  /**
+   * Creates an implementation of {@link TcpHandler} that writes some data to the socket.
+   * 
+   * @param data the data buffer
+   * @param offset the starting offset
+   * @param length the number of bytes to write
+   * @return a handler
+   */
+  public static TcpHandler writeData(final byte[] data, final int offset, final int length) {
+    return new TcpHandler() {
+      @Override
+      public void apply(Socket socket) throws IOException {
+        socket.getOutputStream().write(data, offset, length);
+      }
+    };
+  }
+
+  /**
+   * Creates an implementation of {@link TcpHandler} that writes a UTF-8 string to the socket.
+   * 
+   * @param s the string
+   * @return a handler
+   */
+  public static TcpHandler writeString(String s) {
+    byte[] data = s.getBytes(Charset.forName("UTF-8"));
+    return writeData(data, 0, data.length);
+  }
+  
+  /**
+   * Creates an implementation of {@link TcpHandler} that, for each incoming request, opens
+   * a socket connection to the specified port and then forwards all traffic from the incoming
+   * request to that socket, and vice versa.
+   * 
+   * @param forwardToPort the port to forward to
+   * @return a handler
+   */
+  public static TcpHandler forwardToPort(final int forwardToPort) {
+    return new TcpHandler() {
+      @Override
+      public void apply(Socket incomingSocket) throws IOException {
+        InputStream incomingSocketRead = incomingSocket.getInputStream();
+        OutputStream incomingSocketWrite = incomingSocket.getOutputStream();
+        try (Socket forwardedSocket = new Socket(incomingSocket.getInetAddress().getHostAddress(), forwardToPort)) {
+          InputStream forwardedSocketRead = forwardedSocket.getInputStream();
+          OutputStream forwardedSocketWrite = forwardedSocket.getOutputStream();
+          final CountDownLatch closeSignal = new CountDownLatch(1);
+          new Thread(newForwarder(incomingSocketRead, forwardedSocketWrite, closeSignal)).start();
+          new Thread(newForwarder(forwardedSocketRead, incomingSocketWrite, closeSignal)).start();
+          try {
+            closeSignal.await();
+          } catch (InterruptedException e) {}
+        }
+      }
+    };
+  }
+  
+  private static Runnable newForwarder(InputStream fromStream, OutputStream toStream, CountDownLatch closeSignal) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        byte[] buffer = new byte[1000];
+        while (true) {
+          try {
+            int n = fromStream.read(buffer);
+            if (n < 0) {
+               break;
+            }
+            toStream.write(buffer, 0, n);
+            toStream.flush();
+          } catch (IOException e) {
+            break;
+          }
+        }
+        closeSignal.countDown();
+      }
+    };
+  }
+  
+  /**
+   * Returns an implementation of {@link TcpHandler} that immediately exits, so that
+   * {@link TcpServer} will close the socket with no response.
+   * <p>
+   * A typical use case would be to simulate an I/O error when testing client code that is
+   * making HTTP requests; if the (simulated) HTTP server closes the socket without writing
+   * a response, clients will treat this as a broken connection error.
+   * 
+   * @return a handler
+   */
+  public static TcpHandler noResponse() {
+    return new TcpHandler() {
+      @Override
+      public void apply(Socket socket) {}
+    };
+  }
+  
+  /**
+   * Creates a stateful {@link TcpHandler} that delegates to each of the specified handlers in sequence
+   * as each request is received.
+   * 
+   * @param handlers a sequence of handlers
+   * @return a handler
+   */
+  public static TcpHandler sequential(TcpHandler... handlers) {
+    final AtomicInteger index = new AtomicInteger(0);
+    final TcpHandler[] h = Arrays.copyOf(handlers, handlers.length);
+
+    return new TcpHandler() {
+      @Override
+      public void apply(Socket socket) throws IOException {
+        int i = index.getAndIncrement();
+        if (i >= h.length) {
+          throw new RuntimeException("received more requests than the number of configured handlers");
+        }
+        h[i].apply(socket);
+      }
+    };
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandlers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpHandlers.java
@@ -11,6 +11,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Factory methods for standard {@link TcpHandler} implementations.
+ * 
+ * @since 1.3.0
  */
 public abstract class TcpHandlers {
   private TcpHandlers() {}

--- a/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpServer.java
+++ b/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpServer.java
@@ -16,7 +16,7 @@ import java.util.Date;
  * any particular protocol that might be used over TCP. See {@link TcpHandlers} for examples
  * of configurable behavior.
  * 
- * @since 2.0.0
+ * @since 1.3.0
  */
 public class TcpServer implements Closeable {
   private final ServerSocket listener;

--- a/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpServer.java
+++ b/src/main/java/com/launchdarkly/testhelpers/tcptest/TcpServer.java
@@ -1,0 +1,118 @@
+package com.launchdarkly.testhelpers.tcptest;
+
+import com.launchdarkly.testhelpers.httptest.HttpServer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.Date;
+
+/**
+ * A simple mechanism for creating a TCP listener and configuring its behavior.
+ * <p>
+ * This is analogous to {@link HttpServer}, but much simpler since it has no knowledge of
+ * any particular protocol that might be used over TCP. See {@link TcpHandlers} for examples
+ * of configurable behavior.
+ * 
+ * @since 2.0.0
+ */
+public class TcpServer implements Closeable {
+  private final ServerSocket listener;
+  private final int listenerPort;
+  
+  /**
+   * Starts a new TCP test server on a specific port.
+   * 
+   * @param port the port to listen on
+   * @param handler a {@link TcpHandler} implementation
+   * @return a server
+   */
+  public static TcpServer start(int port, TcpHandler handler) {
+    return new TcpServer(port, handler);
+  }
+
+  /**
+   * Starts a new TCP test server on any available port.
+   * 
+   * @param handler a {@link TcpHandler} implementation
+   * @return a server
+   */
+  public static TcpServer start(TcpHandler handler) {
+    return new TcpServer(0, handler);
+  }
+
+  TcpServer(int port, final TcpHandler handler) {
+    try {
+      listener = new ServerSocket(port);
+    } catch (IOException e) {
+      throw new RuntimeException("unable to create TCP listener", e);
+    }
+    listenerPort = port == 0 ? listener.getLocalPort() : port;
+
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (true) {
+          final Socket socket;
+          try {
+            socket = listener.accept();
+          } catch (IOException e) {
+            // almost certainly means we closed the socket
+            return;
+          }
+          new Thread(new Runnable() {
+            @Override
+            public void run() {
+              try {
+                handler.apply(socket);
+              } catch (Exception e) {
+                logError("handler threw exception: " + e);
+              }
+              try {
+                socket.close();
+              } catch (IOException e) {
+                logError("failed to close socket: " + e);
+              }
+            }
+          }).run();
+        }
+      }
+    }).start();
+  }
+  
+  @Override
+  public void close() {
+    try {
+      listener.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  /**
+   * Returns the port we are listening on.
+   * 
+   * @return the port
+   */
+  public int getPort() {
+    return listenerPort;
+  }
+
+  /**
+   * Convenience method for constructing an HTTP URI with the listener port. This does not
+   * mean the listener necessarily can accept HTTP requests, but it may be useful if for
+   * instance you have configured it with {@link TcpHandlers#forwardToPort(int)} to forward
+   * requests to an {@link HttpServer}.
+   * 
+   * @return an HTTP URI using localhost and the value of {@link #getPort()}
+   */
+  public URI getHttpUri() {
+    return URI.create("http://localhost:" + listenerPort);
+  }
+  
+  private void logError(String message) {
+    System.err.println("TcpServer [" + new Date() + "]: " + message);
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/httptest/HandlersTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/httptest/HandlersTest.java
@@ -170,6 +170,7 @@ public class HandlersTest {
     }
   }
   
+  @SuppressWarnings("deprecation")
   @Test(expected=IOException.class)
   public void malformedResponse() throws Exception {
     try (HttpServer server = HttpServer.start(Handlers.malformedResponse())) {

--- a/src/test/java/com/launchdarkly/testhelpers/tcptest/TcpHandlersTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/tcptest/TcpHandlersTest.java
@@ -1,0 +1,94 @@
+package com.launchdarkly.testhelpers.tcptest;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+import static com.launchdarkly.testhelpers.tcptest.TestUtil.readStreamFully;
+import static com.launchdarkly.testhelpers.tcptest.TestUtil.toUtf8Bytes;
+import static com.launchdarkly.testhelpers.tcptest.TestUtil.toUtf8String;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("javadoc")
+public class TcpHandlersTest {
+  @Test
+  public void writeData() throws IOException {
+    byte[] expected = new byte[] { 100, 101, 102 };
+    TcpHandler handler = TcpHandlers.writeData(expected, 0, expected.length);
+    
+    try (TcpServer server = TcpServer.start(handler)) {
+      try (Socket s = new Socket("localhost", server.getPort())) {
+        byte[] actual = readStreamFully(s.getInputStream());
+        assertArrayEquals(expected, actual);
+      }
+    }
+  }
+
+  @Test
+  public void writeString() throws IOException {
+    String message = "hello";
+    TcpHandler handler = TcpHandlers.writeString(message);
+    
+    try (TcpServer server = TcpServer.start(handler)) {
+      try (Socket s = new Socket("localhost", server.getPort())) {
+        assertEquals(message, toUtf8String(readStreamFully(s.getInputStream())));
+      }
+    }
+  }
+  
+  @Test
+  public void forwardToPort() throws IOException {
+    String question = "question?";
+    String answer = "answer!";
+    ByteArrayOutputStream receivedData = new ByteArrayOutputStream();
+    TcpHandler handler = new TcpHandler() {
+      @Override
+      public void apply(Socket socket) throws IOException {
+        byte[] data = TestUtil.readStream(socket.getInputStream(), toUtf8Bytes(question).length);
+        receivedData.write(data);
+        TcpHandlers.writeString(answer).apply(socket);
+      }
+    };
+    
+    try (TcpServer underlyingServer = TcpServer.start(handler)) {
+      try (TcpServer forwardingServer = TcpServer.start(TcpHandlers.forwardToPort(underlyingServer.getPort()))) {
+        try (Socket s = new Socket("localhost", forwardingServer.getPort())) {
+          TcpHandlers.writeString(question).apply(s);
+          assertEquals(answer, toUtf8String(readStreamFully(s.getInputStream())));
+        }
+      }
+    }
+  }
+  
+  @Test
+  public void noResponse() throws IOException {
+    TcpHandler handler = TcpHandlers.noResponse();
+    
+    try (TcpServer server = TcpServer.start(handler)) {
+      try (Socket s = new Socket("localhost", server.getPort())) {
+        byte[] data = readStreamFully(s.getInputStream());
+        assertEquals(0, data.length);
+      }
+    }
+  }
+  
+  @Test
+  public void sequential() throws IOException {
+    String message = "hello";
+    TcpHandler handler = TcpHandlers.sequential(
+        TcpHandlers.noResponse(),
+        TcpHandlers.writeString(message));
+    
+    try (TcpServer server = TcpServer.start(handler)) {
+      try (Socket s1 = new Socket("localhost", server.getPort())) {
+        assertEquals("", toUtf8String(readStreamFully(s1.getInputStream())));
+      }
+      try (Socket s2 = new Socket("localhost", server.getPort())) {
+        assertEquals(message, toUtf8String(readStreamFully(s2.getInputStream())));
+      }
+    }
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/tcptest/TcpServerTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/tcptest/TcpServerTest.java
@@ -1,0 +1,42 @@
+package com.launchdarkly.testhelpers.tcptest;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import static com.launchdarkly.testhelpers.tcptest.TestUtil.doesPortHaveListener;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings("javadoc")
+public class TcpServerTest {
+  @Test
+  public void listensOnAnyAvailablePort() throws IOException {
+    int port;
+    try (TcpServer server = TcpServer.start(TcpHandlers.noResponse())) {
+      assertNotEquals(0, server.getPort());
+      port = server.getPort();
+      try (Socket s = new Socket("localhost", server.getPort())) {} // just verify that we can connect
+    }
+    assertFalse("expected listener to be closed, but it wasn't", doesPortHaveListener(port));
+  }
+
+  @Test
+  public void listensOnSpecificPort() throws IOException {
+    int specificPort = 10000;
+    while (doesPortHaveListener(specificPort)) {
+      if (specificPort == 65535) {
+        fail("test could not find an available port");
+      }
+      specificPort++; 
+    }
+    try (TcpServer server = TcpServer.start(specificPort, TcpHandlers.noResponse())) {
+      assertEquals(specificPort, server.getPort());
+      try (Socket s = new Socket("localhost", specificPort)) {} // just verify that we can connect
+    }
+    assertFalse("expected listener to be closed, but it wasn't", doesPortHaveListener(specificPort));
+  }
+}

--- a/src/test/java/com/launchdarkly/testhelpers/tcptest/TestUtil.java
+++ b/src/test/java/com/launchdarkly/testhelpers/tcptest/TestUtil.java
@@ -1,0 +1,47 @@
+package com.launchdarkly.testhelpers.tcptest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.nio.charset.Charset;
+
+@SuppressWarnings("javadoc")
+public class TestUtil {
+  public static boolean doesPortHaveListener(int port) {
+    try {
+      try (Socket s = new Socket("localhost", port)) {}
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  public static byte[] readStreamFully(InputStream input) throws IOException {
+    return readStream(input, -1);
+  }
+
+  public static byte[] readStream(InputStream input, int maxLength) throws IOException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1000];
+    while (true) {
+      int n = input.read(buffer);
+      if (n < 0) {
+        break;
+      }
+      bytes.write(buffer, 0, n);
+      if (maxLength > 0 && bytes.size() >= maxLength) {
+        break;
+      }
+    }
+    return bytes.toByteArray();
+  }
+  
+  public static String toUtf8String(byte[] data) {
+    return new String(data, Charset.forName("UTF-8"));
+  }
+  
+  public static byte[] toUtf8Bytes(String s) {
+    return s.getBytes(Charset.forName("UTF-8"));
+  }
+}


### PR DESCRIPTION
This adds a `tcptest` package that's similar in principle to `httptest`, but much simpler, providing a quick way to set up a TCP listener with configurable behavior.

The use case for us is in simulating certain server error conditions where the server does not return a valid HTTP response (which normally results in the client getting an `IOException`, so we might want to validate that we handle such an exception correctly). Since embedded HTTP servers generally enforce that the protocol usage is valid, it's difficult to make them behave in an invalid way so as to simulate a condition like "connection was closed without a response"; currently java-test-helpers does this via a very hacky and Jetty-specific method. But a more generic TCP listener can easily be configured to do this. For instance:

```java
@Test
public void firstHttpRequestGetsAnIOErrorAndThenSecondRequestSucceeds() {
  try (HttpServer httpServer = HttpServer.start(Handlers.bodyString("text/plain", "hello")) {
    TcpHandler tcpHandler = TcpHandlers.sequential(
      TcpHandlers.noResponse(), // for first request
      TcpHandlers.forwardToPort(httpServer.getPort()) // for second request
    );
    try (TcpServer tcpServer = TcpServer.start(tcpHandler)) {
      doSomeHttpRequests(tcpServer.getHttpUri());
    }
  }
}
```

This is a prerequisite for us being able to drop the Jetty embedded server implementation.