### PR TITLE
port the "test with various special HTTP configurations" logic from java-server-sdk

### DIFF
--- a/src/main/java/com/launchdarkly/testhelpers/httptest/SpecialHttpConfigurations.java
+++ b/src/main/java/com/launchdarkly/testhelpers/httptest/SpecialHttpConfigurations.java
@@ -1,0 +1,389 @@
+package com.launchdarkly.testhelpers.httptest;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.URI;
+
+import javax.net.SocketFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Testing tools for validating that HTTP client logic is correctly applying configuration parameters.
+ * The test methods set up a server with a defined behavior, then delegate to a provided test action
+ * that is expected to succeed or fail depending on the test conditions.
+ * 
+ * @since 1.3.0
+ */
+public class SpecialHttpConfigurations {
+  /**
+   * See {@link TestAction}.
+   */
+  public static class Params {
+    private final ServerTLSConfiguration tlsConfig;
+    private final SocketFactory socketFactory;
+    private final String proxyHost;
+    private final int proxyPort;
+    private final String proxyBasicAuthUser;
+    private final String proxyBasicAuthPassword;
+    
+    Params(ServerTLSConfiguration tlsConfig, SocketFactory socketFactory, String proxyHost, int proxyPort,
+        String proxyBasicAuthUser, String proxyBasicAuthPassword) {
+      this.tlsConfig = tlsConfig;
+      this.socketFactory = socketFactory;
+      this.proxyHost = proxyHost;
+      this.proxyPort = proxyPort;
+      this.proxyBasicAuthUser = proxyBasicAuthUser;
+      this.proxyBasicAuthPassword = proxyBasicAuthPassword;
+    }
+
+    /**
+     * If the {@link ServerTLSConfiguration#getSocketFactory()} and {@link ServerTLSConfiguration#getTrustManager()}
+     * properties are non-null, the {@link TestAction} should configure its HTTP client to use these
+     * values for TLS configuration.
+     * @return the TLS configuration
+     */
+    public ServerTLSConfiguration getTlsConfig() {
+      return tlsConfig;
+    }
+
+    /**
+     * If this property is non-null, the {@link TestAction} should configure its HTTP client to use it.
+     * @return a custom socket factory
+     */
+    public SocketFactory getSocketFactory() {
+      return socketFactory;
+    }
+
+    /**
+     * If this property is non-null, the {@link TestAction} should configure its HTTP client to use a
+     * web proxy with this hostname plus the other proxy properties.
+     * @return the proxy hostname
+     */
+    public String getProxyHost() {
+      return proxyHost;
+    }
+
+    /**
+     * See {@link #getProxyHost()}.
+     * @return the proxy port
+     */
+    public int getProxyPort() {
+      return proxyPort;
+    }
+
+    /**
+     * See {@link #getProxyHost()}.
+     * @return the username for proxy basicauth or null
+     */
+    public String getProxyBasicAuthUser() {
+      return proxyBasicAuthUser;
+    }
+
+    /**
+     * See {@link #getProxyHost()}.
+     * @return the password for proxy basicauth or null
+     */
+    public String getProxyBasicAuthPassword() {
+      return proxyBasicAuthPassword;
+    }
+  }
+  
+  /**
+   * See {@link TestAction}.
+   */
+  @SuppressWarnings("serial")
+  public static class UnexpectedResponseException extends Exception {
+    @SuppressWarnings("javadoc")
+    public UnexpectedResponseException(String message) {
+      super(message);
+    }
+  }
+  
+  /**
+   * Implemented by the caller to perform some action against an HTTP server.
+   */
+  public interface TestAction {
+    /**
+     * Implement this method to perform whatever kind of HTTP client action you are testing.
+     * The test framework has already set up a server with some predefined configuration, and has
+     * provided the base URI of that server in {@code targetUri}. The properties in {@code params}
+     * indicate how you should customize your HTTP client. The goal is to verify that 1. these
+     * features (such as TLS and proxy configuration) work correctly in the client and 2. your
+     * configuration logic is accurately transferring these parameters to the client.
+     *
+     * @param targetUri the URI to query
+     * @param params client configuration options
+     * @return true if successful; false if your client implementation does not support some of
+     *   those parameters and you are deliberately skipping this test
+     * @throws IOException
+     * @throws UnexpectedResponseException if you were able to connect and send the request, but
+     *   the content of the response was not consistent with the {@code handler} you passed to
+     *   the test method
+     */
+    boolean doTest(URI targetUri, Params params) throws IOException, UnexpectedResponseException;
+  }
+  
+  /**
+   * Runs all of the other {@code test} methods with the same client logic.
+   * 
+   * @param handler determines what the server should return for all responses
+   * @param testAction a {@link TestAction} implementation
+   */
+  public static void testAll(
+      Handler handler,
+      TestAction testAction
+      ) {
+    testHttpClientDoesNotAllowSelfSignedCertByDefault(handler, testAction);
+    testHttpClientCanBeConfiguredToAllowSelfSignedCert(handler, testAction);
+    testHttpClientCanUseCustomSocketFactory(handler, testAction);
+    testHttpClientCanUseProxy(handler, testAction);
+    testHttpClientCanUseProxyWithBasicAuth(handler, testAction);
+  }
+
+  /**
+   * Runs a test to verify that the HTTP client logic in the {@link TestAction} will fail if it
+   * connects to an HTTPS endpoint that has a self-signed certificate, when it has not been
+   * specifically configured to accept that certificate.
+   * 
+   * @param handler determines what the server should return for all responses
+   * @param testAction a {@link TestAction} implementation
+   * @return true if successful; false if the {@link TestAction} returned false to indicate
+   *   that the client does not support this kind of test
+   */
+  public static boolean testHttpClientDoesNotAllowSelfSignedCertByDefault(Handler handler,
+      TestAction testAction) {
+    Params params = new Params(null, null, null, 0, null, null);
+    // deliberately don't include a TLS configuration in the Params, so the client doesn't know about the cert
+    ServerTLSConfiguration tlsConfig = ServerTLSConfiguration.makeSelfSignedCertificate();
+    try (HttpServer secureServer = HttpServer.startSecure(tlsConfig, handler)) {
+      boolean didTest;
+      try {
+        didTest = testAction.doTest(secureServer.getUri(), params);
+        // test was expected to throw an exception, so we should only get here if the test really didn't do anything
+        assertThat("test action appears to have succeeded, but it should have failed", !didTest);
+        return false;
+      } catch (UnexpectedResponseException e) {
+        assertThat("test action was able to get a response, even if its content was invalid; should have gotten an IOException", false);
+      } catch (Exception e) { // any other kind of failure counts as an expected result
+      }
+      assertThat("expected the server not to receive a request due to TLS negotiation failure for a self-signed certificate",
+          secureServer.getRecorder().count(), equalTo(0));
+      return true;
+    }
+  }
+
+  /**
+   * Runs a test to verify that the HTTP client logic in the {@link TestAction} can be
+   * configured to accept a specific HTTPS certificate (which in this case is self-signed).
+   * 
+   * @param handler determines what the server should return for all responses
+   * @param testAction a {@link TestAction} implementation
+   * @return true if successful; false if the {@link TestAction} returned false to indicate
+   *   that the client does not support this kind of test
+   */
+  public static boolean testHttpClientCanBeConfiguredToAllowSelfSignedCert(Handler handler,
+      TestAction testAction) {
+    String desc = "when the client was configured to accept a self-signed certificate";
+    try {
+      ServerTLSConfiguration tlsConfig = ServerTLSConfiguration.makeSelfSignedCertificate();
+      Params params = new Params(tlsConfig, null, null, 0, null, null);
+      try (HttpServer secureServer = HttpServer.startSecure(tlsConfig, handler)) {
+        boolean didTest = testAction.doTest(secureServer.getUri(), params);
+        if (didTest) {
+          assertThat("expected the server to receive a request " + desc,
+              secureServer.getRecorder().count(), equalTo(1));
+        }
+        return didTest;
+      }
+    } catch (Exception e) {
+      throw unexpectedRequestFailure(e, desc);
+    }
+  }
+
+  /**
+   * Runs a test to verify that the HTTP client logic in the {@link TestAction} can be
+   * configured to use a custom {@link SocketFactory}. The test method will provide a
+   * deliberately incorrect URI, plus a custom socket factory that rewrites requests to go
+   * to the correct URI, to verify that the socket factory is really being used.
+   * 
+   * @param handler determines what the server should return for all responses
+   * @param testAction a {@link TestAction} implementation
+   * @return true if successful; false if the {@link TestAction} returned false to indicate
+   *   that the client does not support this kind of test
+   */
+  public static boolean testHttpClientCanUseCustomSocketFactory(Handler handler,
+      TestAction testAction) {
+    String desc = "when the client was configured with a custom socket factory";
+    try {
+      try (HttpServer server = HttpServer.start(handler)) {
+        Params params = new Params(null,
+            makeSocketFactoryThatChangesHostAndPort(server.getUri().getHost(), server.getPort()),
+            null, 0, null, null);
+        URI uriWithWrongPort = URI.create("http://localhost:1");
+        boolean didTest = testAction.doTest(uriWithWrongPort, params);
+        if (didTest) {
+          assertThat("expected the server to receive a request " + desc,
+              server.getRecorder().count(), equalTo(1));
+        }
+        return didTest;
+      }
+    } catch (Exception e) {
+      throw unexpectedRequestFailure(e, desc);
+    }
+  }
+  
+  /**
+   * Runs a test to verify that the HTTP client logic in the {@link TestAction} can be
+   * configured to use a web proxy. The test method will provide a deliberately incorrect
+   * URI, plus the host/port of a fake proxy that accepts requests and returns the
+   * configured response, to verify that the proxy settings are really being used.
+   * 
+   * @param handler determines what the server should return for all responses
+   * @param testAction a {@link TestAction} implementation
+   * @return true if successful; false if the {@link TestAction} returned false to indicate
+   *   that the client does not support this kind of test
+   */
+  public static boolean testHttpClientCanUseProxy(Handler handler,
+      TestAction testAction) {
+    String desc = "when the client was configured with a proxy";
+    try {
+      try (HttpServer server = HttpServer.start(handler)) {
+        Params params = new Params(null, null, server.getUri().getHost(), server.getPort(), null, null);
+        URI fakeBaseUri = URI.create("http://not-a-real-host");
+        boolean didTest = testAction.doTest(fakeBaseUri, params);
+        if (didTest) {
+          assertThat("expected the server to receive a request " + desc,
+              server.getRecorder().count(), equalTo(1));
+        }
+        return didTest;
+      }
+    } catch (Exception e) {
+      throw unexpectedRequestFailure(e, desc);
+    }
+  }
+
+  /**
+   * Runs a test to verify that the HTTP client logic in the {@link TestAction} can be
+   * configured to use a web proxy with basic authentication. The test method will provide
+   * a deliberately incorrect URI, plus the host/port of a fake proxy that accepts requests
+   * and returns the configured response, to verify that the proxy settings are really being
+   * used; then it will verify that the fake proxy received the expected authorization header.
+   * 
+   * @param handler determines what the server should return for all responses
+   * @param testAction a {@link TestAction} implementation
+   * @return true if successful; false if the {@link TestAction} returned false to indicate
+   *   that the client does not support this kind of test
+   */
+  public static boolean testHttpClientCanUseProxyWithBasicAuth(Handler handler,
+      TestAction testAction) {
+    String desc = "when the client was configured with a proxy with basicauth";
+    Handler proxyHandler = ctx -> {
+      if (ctx.getRequest().getHeader("Proxy-Authorization") == null) {
+        ctx.setStatus(407);
+        ctx.setHeader("Proxy-Authenticate", "Basic realm=x");
+      } else {
+        handler.apply(ctx);
+      }
+    };
+    try {
+      try (HttpServer server = HttpServer.start(proxyHandler)) {
+        Params params = new Params(null, null, server.getUri().getHost(), server.getPort(), "user", "pass");
+ 
+        URI fakeBaseUri = URI.create("http://not-a-real-host");
+        boolean didTest = testAction.doTest(fakeBaseUri, params);
+        if (didTest) {
+          assertThat("expected the server to receive two requests " + desc,
+              server.getRecorder().count(), equalTo(2));
+          RequestInfo req1 = server.getRecorder().requireRequest();
+          assertThat("expected the first request not to have a Proxy-Authorization header",
+              req1.getHeader("Proxy-Authorization"), nullValue());
+          RequestInfo req2 = server.getRecorder().requireRequest();
+          assertThat("expected the second request (response to challenge) to have a valid Proxy-Authorization header",
+              req2.getHeader("Proxy-Authorization"), equalTo("Basic dXNlcjpwYXNz"));
+        }
+        return didTest;
+      }
+    } catch (Exception e) {
+      throw unexpectedRequestFailure(e, desc);
+    }
+  }
+  
+  private static AssertionError unexpectedRequestFailure(Exception e, String desc) {
+    return new AssertionError("request failed " + desc + ": " + e);
+  }
+  
+  /**
+   * Creates a {@link SocketFactory} implementation that rewrites all requests to go to the
+   * specified host and port, instead of the ones given in the URI. This is a simple way to
+   * verify that a given piece of client logic is really using the configured socket factory.
+   * 
+   * @param host the hostname to send requests to
+   * @param port the port to send requests to
+   * @return a socket factory
+   */
+  public static SocketFactorySingleHost makeSocketFactoryThatChangesHostAndPort(String host, int port) {
+    return new SocketFactorySingleHost(host, port);
+  }
+  
+  private static final class SocketSingleHost extends Socket {
+    private final String host;
+    private final int port;
+
+    SocketSingleHost(String host, int port) {
+      this.host = host;
+      this.port = port;
+    }
+
+    @Override public void connect(SocketAddress endpoint) throws IOException {
+      super.connect(new InetSocketAddress(this.host, this.port), 0);
+    }
+
+    @Override public void connect(SocketAddress endpoint, int timeout) throws IOException {
+      super.connect(new InetSocketAddress(this.host, this.port), timeout);
+    }
+  }
+
+  static final class SocketFactorySingleHost extends SocketFactory {
+    private final String host;
+    private final int port;
+
+    public SocketFactorySingleHost(String host, int port) {
+      this.host = host;
+      this.port = port;
+    }
+
+    @Override public Socket createSocket() throws IOException {
+      return new SocketSingleHost(this.host, this.port);
+    }
+
+    @Override public Socket createSocket(String host, int port) throws IOException {
+      Socket socket = createSocket();
+      socket.connect(new InetSocketAddress(this.host, this.port));
+      return socket;
+    }
+
+    @Override public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+      Socket socket = createSocket();
+      socket.connect(new InetSocketAddress(this.host, this.port));
+      return socket;
+    }
+
+    @Override public Socket createSocket(InetAddress host, int port) throws IOException {
+      Socket socket = createSocket();
+      socket.connect(new InetSocketAddress(this.host, this.port));
+      return socket;
+    }
+
+    @Override public Socket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort) throws IOException {
+      Socket socket = createSocket();
+      socket.connect(new InetSocketAddress(this.host, this.port));
+      return socket;
+    }
+  }
+}

--- a/src/main/java/com/launchdarkly/testhelpers/httptest/SpecialHttpConfigurations.java
+++ b/src/main/java/com/launchdarkly/testhelpers/httptest/SpecialHttpConfigurations.java
@@ -121,7 +121,7 @@ public class SpecialHttpConfigurations {
      * @param params client configuration options
      * @return true if successful; false if your client implementation does not support some of
      *   those parameters and you are deliberately skipping this test
-     * @throws IOException
+     * @throws IOException if the connection failed
      * @throws UnexpectedResponseException if you were able to connect and send the request, but
      *   the content of the response was not consistent with the {@code handler} you passed to
      *   the test method

--- a/src/test/java/com/launchdarkly/testhelpers/httptest/SpecialHttpConfigurationsTest.java
+++ b/src/test/java/com/launchdarkly/testhelpers/httptest/SpecialHttpConfigurationsTest.java
@@ -1,0 +1,171 @@
+package com.launchdarkly.testhelpers.httptest;
+
+import com.launchdarkly.testhelpers.httptest.SpecialHttpConfigurations.Params;
+import com.launchdarkly.testhelpers.httptest.SpecialHttpConfigurations.UnexpectedResponseException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+
+import static org.junit.Assert.assertFalse;
+
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+@SuppressWarnings("javadoc")
+public class SpecialHttpConfigurationsTest {
+  private static final int EXPECTED_STATUS = 418;
+  
+  // An implementation of TestAction that just converts the specified parameters to OkHttp settings
+  // and makes a request with the OkHttp client.
+  public static class MyTestClientAction implements SpecialHttpConfigurations.TestAction {
+    @Override
+    public boolean doTest(URI targetUri, Params params) throws IOException, SpecialHttpConfigurations.UnexpectedResponseException {
+      OkHttpClient.Builder cb = new OkHttpClient.Builder();
+      if (params.getTlsConfig() != null && params.getTlsConfig().getSocketFactory() != null) {
+        cb.sslSocketFactory(params.getTlsConfig().getSocketFactory(), params.getTlsConfig().getTrustManager());
+      }
+      if (params.getSocketFactory() != null) {
+        cb.socketFactory(params.getSocketFactory());
+      }
+      if (params.getProxyHost() != null) {
+        cb.proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(params.getProxyHost(), params.getProxyPort())));
+        if (params.getProxyBasicAuthUser() != null) {
+          cb.proxyAuthenticator(new Authenticator() {
+            public Request authenticate(Route route, Response response) throws IOException {
+              return response.request().newBuilder()
+                  .header("Proxy-Authorization",
+                      Credentials.basic(params.getProxyBasicAuthUser(), params.getProxyBasicAuthPassword()))
+                  .build();
+            }
+          });
+        }
+      }
+
+      OkHttpClient client = cb.build();
+      
+      Request req = new Request.Builder().url(targetUri.toString()).build();
+      
+      Response resp = client.newCall(req).execute();
+      if (resp.code() != EXPECTED_STATUS) { // we know we will be configuring the server with testActionHandler()
+        throw new SpecialHttpConfigurations.UnexpectedResponseException("got unexpected response status " + resp.code());
+      }
+
+      return true;
+    }
+  }
+  
+  private static Handler testActionHandler() {
+    return Handlers.status(EXPECTED_STATUS);
+  }
+  
+  @Test
+  public void testAllCorrect() {
+    SpecialHttpConfigurations.testAll(testActionHandler(), new MyTestClientAction());
+  }
+
+  @Test
+  public void testSelfSignedCertFails() {
+    SpecialHttpConfigurations.TestAction testActionThatIgnoresTlsConfigParam = new SpecialHttpConfigurations.TestAction() {
+      @Override
+      public boolean doTest(URI targetUri, Params params) throws IOException, UnexpectedResponseException {
+        params = new Params(null,
+           params.getSocketFactory(),  params.getProxyHost(), params.getProxyPort(),
+           params.getProxyBasicAuthUser(), params.getProxyBasicAuthPassword());
+        return new MyTestClientAction().doTest(targetUri, params);
+      }
+    };
+    boolean passed = false;
+    try {
+      SpecialHttpConfigurations.testHttpClientCanBeConfiguredToAllowSelfSignedCert(testActionHandler(),
+          testActionThatIgnoresTlsConfigParam);
+      passed = true;
+    } catch (AssertionError e) {}
+    assertFalse("expected test to fail", passed);
+  }
+  
+  @Test
+  public void testSocketFactoryFails() {
+    SpecialHttpConfigurations.TestAction testActionThatIgnoresSocketFactoryParam = new SpecialHttpConfigurations.TestAction() {
+      @Override
+      public boolean doTest(URI targetUri, Params params) throws IOException, UnexpectedResponseException {
+        params = new Params(params.getTlsConfig(),
+            null,
+            params.getProxyHost(), params.getProxyPort(), params.getProxyBasicAuthUser(), params.getProxyBasicAuthPassword());
+        return new MyTestClientAction().doTest(targetUri, params);
+      }
+    };
+    boolean passed = false;
+    try {
+      SpecialHttpConfigurations.testHttpClientCanUseCustomSocketFactory(testActionHandler(),
+          testActionThatIgnoresSocketFactoryParam);
+      passed = true;
+    } catch (AssertionError e) {}
+    assertFalse("expected test to fail", passed);
+  }
+  
+  @Test
+  public void testProxyFails() {
+    SpecialHttpConfigurations.TestAction testActionThatIgnoresProxyParams = new SpecialHttpConfigurations.TestAction() {
+      @Override
+      public boolean doTest(URI targetUri, Params params) throws IOException, UnexpectedResponseException {
+        params = new Params(params.getTlsConfig(), params.getSocketFactory(),
+            null, 0,
+            params.getProxyBasicAuthUser(), params.getProxyBasicAuthPassword());
+        return new MyTestClientAction().doTest(targetUri, params);
+      }
+    };
+    boolean passed = false;
+    try {
+      SpecialHttpConfigurations.testHttpClientCanUseProxy(testActionHandler(),
+          testActionThatIgnoresProxyParams);
+      passed = true;
+    } catch (AssertionError e) {}
+    assertFalse("expected test to fail", passed);
+  }
+  
+  @Test
+  public void testProxyAuthFailsWithNoAuthProvided() {
+    SpecialHttpConfigurations.TestAction testActionThatIgnoresProxyAuthParams = new SpecialHttpConfigurations.TestAction() {
+      @Override
+      public boolean doTest(URI targetUri, Params params) throws IOException, UnexpectedResponseException {
+        params = new Params(params.getTlsConfig(), params.getSocketFactory(), params.getProxyHost(), params.getProxyPort(),
+            null, null);
+        return new MyTestClientAction().doTest(targetUri, params);
+      }
+    };
+    boolean passed = false;
+    try {
+      SpecialHttpConfigurations.testHttpClientCanUseProxyWithBasicAuth(testActionHandler(),
+          testActionThatIgnoresProxyAuthParams);
+      passed = true;
+    } catch (AssertionError e) {}
+    assertFalse("expected test to fail", passed);
+  }
+  
+  @Test
+  public void testProxyAuthFailsWithWrongAuthProvided() {
+    SpecialHttpConfigurations.TestAction testActionThatChangesProxyAuthParams = new SpecialHttpConfigurations.TestAction() {
+      @Override
+      public boolean doTest(URI targetUri, Params params) throws IOException, UnexpectedResponseException {
+        params = new Params(params.getTlsConfig(), params.getSocketFactory(), params.getProxyHost(), params.getProxyPort(),
+            params.getProxyBasicAuthUser(), "x" + params.getProxyBasicAuthPassword());
+        return new MyTestClientAction().doTest(targetUri, params);
+      }
+    };
+    boolean passed = false;
+    try {
+      SpecialHttpConfigurations.testHttpClientCanUseProxyWithBasicAuth(testActionHandler(),
+          testActionThatChangesProxyAuthParams);
+      passed = true;
+    } catch (AssertionError e) {}
+    assertFalse("expected test to fail", passed);
+  }
+}


### PR DESCRIPTION
This is based on a [similar test helper](https://github.com/launchdarkly/java-server-sdk/blob/main/src/test/java/com/launchdarkly/sdk/server/TestHttpUtil.java#L23) that's currently defined in the unit tests for `launchdarkly-java-server-sdk`. The purpose of putting it into `java-test-helpers` is so LaunchDarkly can reuse it in other projects such as `java-sdk-internal` and `android-client-sdk`, but it could be helpful in other Java projects too.

The goal is that for any given component that makes HTTP requests, we can consistently verify that it supports all of the HTTP configuration options that we intend for it to support, and its configuration API for those options works as expected. For instance, if we have an option for configuring a web proxy, then setting that option really does cause the component to make requests to that proxy. The test helper is agnostic to what the component is and what its configuration methods are; instead, it calls a callback that you provide, whose purpose is "apply these options and make the component do whatever it's supposed to do, and throw an exception if it failed."

The test _for_ these tests (SpecialHttpConfigurationsTest) simply uses OkHttpClient; since we already know that OkHttpClient supports proxies etc., such a test verifies that the test logic is correctly setting up the server so that the test will pass if the client is valid. Currently, LaunchDarkly's SDKs also use OkHttpClient internally— but even though we know that OkHttp is valid, we still want to prove that our code is using the OkHttp API correctly.