### PR TITLE
remove uses of java.time

### DIFF
--- a/src/main/java/com/launchdarkly/testhelpers/httptest/Handlers.java
+++ b/src/main/java/com/launchdarkly/testhelpers/httptest/Handlers.java
@@ -1,7 +1,6 @@
 package com.launchdarkly.testhelpers.httptest;
 
 import java.nio.charset.Charset;
-import java.time.Duration;
 import java.util.concurrent.Semaphore;
 
 /**
@@ -177,13 +176,13 @@ public abstract class Handlers {
   /**
    * Creates a {@link Handler} that sleeps for the specified amount of time.
    * 
-   * @param delay how long to delay
+   * @param delayMillis how long to delay, in milliseconds
    * @return a {@link Handler}
    */
-  public static Handler delay(Duration delay) {
+  public static Handler delay(long delayMillis) {
     return ctx -> {
       try {
-        Thread.sleep(delay.toMillis());
+        Thread.sleep(delayMillis);
       } catch (InterruptedException e) {}
     };
   }

--- a/src/main/java/com/launchdarkly/testhelpers/httptest/RequestRecorder.java
+++ b/src/main/java/com/launchdarkly/testhelpers/httptest/RequestRecorder.java
@@ -1,6 +1,5 @@
 package com.launchdarkly.testhelpers.httptest;
 
-import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +17,7 @@ public final class RequestRecorder implements Handler {
   /**
    * The default timeout for {@link #requireRequest()}: 5 seconds.
    */
-  public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+  public static final int DEFAULT_TIMEOUT_MILLIS = 5000;
   
   private final BlockingQueue<RequestInfo> requests = new LinkedBlockingQueue<>();
   private final AtomicBoolean enabled = new AtomicBoolean(true);
@@ -59,25 +58,26 @@ public final class RequestRecorder implements Handler {
   
   /**
    * Consumes and returns the first request in the queue, blocking until one is available,
-   * using {@link #DEFAULT_TIMEOUT}.
+   * using {@link #DEFAULT_TIMEOUT_MILLIS}.
    * 
    * @return the request information
    * @throws IllegalStateException if the timeout expires
    */
   public RequestInfo requireRequest() {
-    return requireRequest(DEFAULT_TIMEOUT);
+    return requireRequest(DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
   
   /**
    * Consumes and returns the first request in the queue, blocking until one is available.
    * 
    * @param timeout the maximum length of time to wait
+   * @param timeoutUnit the time unit for the timeout
    * @return the request information
    * @throws RuntimeException if the timeout expires
    */
-  public RequestInfo requireRequest(Duration timeout) {
+  public RequestInfo requireRequest(long timeout, TimeUnit timeoutUnit) {
     try {
-      RequestInfo ret = requests.poll(timeout.toNanos(), TimeUnit.NANOSECONDS);
+      RequestInfo ret = requests.poll(timeout, timeoutUnit == null ? TimeUnit.MILLISECONDS : timeoutUnit);
       if (ret == null) {
         throw new IllegalStateException(new TimeoutException());
       }
@@ -92,11 +92,12 @@ public final class RequestRecorder implements Handler {
    * the specified timeout.
    * 
    * @param timeout the maximum length of time to wait
+   * @param timeoutUnit the time unit for the timeout
    * @throws IllegalStateException if a request was received
    */
-  public void requireNoRequests(Duration timeout) {
+  public void requireNoRequests(long timeout, TimeUnit timeoutUnit) {
     try {
-      RequestInfo ret = requests.poll(timeout.toNanos(), TimeUnit.NANOSECONDS);
+      RequestInfo ret = requests.poll(timeout, timeoutUnit == null ? TimeUnit.MILLISECONDS : timeoutUnit);
       if (ret != null) {
          throw new IllegalStateException("received an unexpected request");
       }

--- a/src/test/java/com/launchdarkly/testhelpers/httptest/TestUtil.java
+++ b/src/test/java/com/launchdarkly/testhelpers/httptest/TestUtil.java
@@ -1,7 +1,7 @@
 package com.launchdarkly.testhelpers.httptest;
 
 import java.net.URI;
-import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -10,7 +10,7 @@ import okhttp3.Response;
 @SuppressWarnings("javadoc")
 public class TestUtil {
   public static final OkHttpClient client = new OkHttpClient.Builder()
-      .readTimeout(Duration.ofMinutes(5))
+      .readTimeout(5, TimeUnit.MINUTES)
       .retryOnConnectionFailure(false)
       .build();
   


### PR DESCRIPTION
For maximum Android compatibility, we need to avoid using this Java 8 package.